### PR TITLE
fix(ui): add unassigned filter, fix pickers, optimize queries

### DIFF
--- a/linear.go
+++ b/linear.go
@@ -99,7 +99,7 @@ type Team struct {
 func NewLinearClient(apiKey string) *LinearClient {
 	return &LinearClient{
 		apiKey: apiKey,
-		client: &http.Client{Timeout: 15 * time.Second},
+		client: &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
@@ -200,6 +200,19 @@ func (lc *LinearClient) GetTeamByKey(key string) (*Team, error) {
 	return &result.Teams.Nodes[0], nil
 }
 
+// issueListFields is the lightweight field set for list queries.
+// Only includes fields needed for list rendering and list-level actions (open, assign, comment).
+// Detail-only fields (description, branchName, estimate, labels, cycle, timestamps,
+// parent, relations) are fetched on demand via issueFields.
+const issueListFields = `
+	id identifier title priority url dueDate
+	state { name type color }
+	assignee { id name displayName }
+	project { id name }
+	children { nodes { id identifier title state { name type } } }
+`
+
+// issueFields is the full field set for detail/search queries.
 const issueFields = `
 	id identifier title description priority url branchName
 	estimate dueDate createdAt updatedAt
@@ -224,7 +237,7 @@ const issueQueryTemplate = `
 			after: $after
 			orderBy: updatedAt
 		) {
-			nodes { ` + issueFields + ` }
+			nodes { ` + issueListFields + ` }
 			pageInfo { hasNextPage endCursor }
 		}
 	}`
@@ -239,6 +252,9 @@ var issueFilterByMode = map[FilterMode]string{
 		{ state: { type: { eq: "unstarted" } } }`,
 	FilterInProgress: `
 		{ state: { type: { eq: "started" } } }`,
+	FilterUnassigned: `
+		{ assignee: { null: true } },
+		{ state: { type: { nin: ["completed", "cancelled"] } } }`,
 }
 
 func (lc *LinearClient) GetIssues(teamID string, filter FilterMode, after string) ([]Issue, PageInfo, error) {
@@ -414,7 +430,7 @@ func (lc *LinearClient) GetIssuesByProject(teamID, projectID, after string) ([]I
 				nodes { %s }
 				pageInfo { hasNextPage endCursor }
 			}
-		}`, issueFields)
+		}`, issueListFields)
 
 	var result struct {
 		Issues struct {
@@ -424,6 +440,40 @@ func (lc *LinearClient) GetIssuesByProject(teamID, projectID, after string) ([]I
 	}
 
 	vars := map[string]any{"teamID": teamID, "projectID": projectID}
+	if after != "" {
+		vars["after"] = after
+	}
+
+	err := lc.queryWithVars(q, vars, &result)
+	return result.Issues.Nodes, result.Issues.PageInfo, err
+}
+
+func (lc *LinearClient) GetIssuesWithNoProject(teamID string, filter FilterMode, after string) ([]Issue, PageInfo, error) {
+	q := fmt.Sprintf(`
+		query($teamID: ID!, $after: String) {
+			issues(
+				filter: { and: [
+					{ team: { id: { eq: $teamID } } },
+					{ project: { null: true } },
+					%s
+				] }
+				first: 50
+				after: $after
+				orderBy: updatedAt
+			) {
+				nodes { `+issueListFields+` }
+				pageInfo { hasNextPage endCursor }
+			}
+		}`, issueFilterByMode[filter])
+
+	var result struct {
+		Issues struct {
+			Nodes    []Issue  `json:"nodes"`
+			PageInfo PageInfo `json:"pageInfo"`
+		} `json:"issues"`
+	}
+
+	vars := map[string]any{"teamID": teamID}
 	if after != "" {
 		vars["after"] = after
 	}
@@ -553,23 +603,26 @@ const (
 	FilterAll
 	FilterTodo
 	FilterInProgress
+	FilterUnassigned
 )
 
 func (f FilterMode) String() string {
 	switch f {
 	case FilterAssigned:
-		return "👤 Assigned to me"
+		return "Assigned to me"
 	case FilterAll:
-		return "📋 All"
+		return "All"
 	case FilterTodo:
-		return "○ Todo"
+		return "Todo"
 	case FilterInProgress:
-		return "● In Progress"
+		return "In Progress"
+	case FilterUnassigned:
+		return "Unassigned"
 	default:
 		return "?"
 	}
 }
 
 func (f FilterMode) Next() FilterMode {
-	return (f + 1) % 4
+	return (f + 1) % 5
 }

--- a/linear_test.go
+++ b/linear_test.go
@@ -16,7 +16,8 @@ func TestFilterModeNext(t *testing.T) {
 		{FilterAssigned, FilterAll},
 		{FilterAll, FilterTodo},
 		{FilterTodo, FilterInProgress},
-		{FilterInProgress, FilterAssigned}, // wraps around
+		{FilterInProgress, FilterUnassigned},
+		{FilterUnassigned, FilterAssigned}, // wraps around
 	}
 
 	for _, tt := range tests {
@@ -33,6 +34,9 @@ func TestFilterModeString(t *testing.T) {
 	}
 	if s := FilterAll.String(); s == "" {
 		t.Error("FilterAll.String() should not be empty")
+	}
+	if s := FilterUnassigned.String(); s != "Unassigned" {
+		t.Errorf("FilterUnassigned.String() = %q, want %q", s, "Unassigned")
 	}
 }
 
@@ -330,6 +334,34 @@ func TestLinearClientGetIssuesByProject(t *testing.T) {
 	issues, pageInfo, err := testClient(server).GetIssuesByProject("team-1", "proj-1", "")
 	if err != nil {
 		t.Fatalf("GetIssuesByProject() error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if pageInfo.HasNextPage {
+		t.Error("expected no next page")
+	}
+}
+
+func TestLinearClientGetIssuesWithNoProject(t *testing.T) {
+	server := mockLinearServer(func(query string, vars map[string]any) (int, interface{}) {
+		return 200, map[string]interface{}{
+			"issues": map[string]interface{}{
+				"nodes": []map[string]interface{}{
+					{"id": "issue-1", "identifier": "TEST-1", "title": "No project issue"},
+				},
+				"pageInfo": map[string]interface{}{
+					"hasNextPage": false,
+					"endCursor":   "",
+				},
+			},
+		}
+	})
+	defer server.Close()
+
+	issues, pageInfo, err := testClient(server).GetIssuesWithNoProject("team-1", FilterAll, "")
+	if err != nil {
+		t.Fatalf("GetIssuesWithNoProject() error: %v", err)
 	}
 	if len(issues) != 1 {
 		t.Fatalf("expected 1 issue, got %d", len(issues))

--- a/model.go
+++ b/model.go
@@ -33,8 +33,8 @@ var (
 			Padding(0, 1)
 
 	issueIdentStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#06B6D4")).
-				Bold(true)
+			Foreground(lipgloss.Color("#06B6D4")).
+			Bold(true)
 
 	worktreeMarker = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#22C55E"))
@@ -98,6 +98,15 @@ func (i issueItem) Title() string {
 
 func (i issueItem) Description() string {
 	var parts []string
+	if i.issue.Assignee != nil {
+		name := i.issue.Assignee.DisplayName
+		if name == "" {
+			name = i.issue.Assignee.Name
+		}
+		parts = append(parts, name)
+	} else {
+		parts = append(parts, "Unassigned")
+	}
 	if i.issue.Project != nil {
 		parts = append(parts, i.issue.Project.Name)
 	}
@@ -274,6 +283,7 @@ const (
 	viewPrompt
 	viewProjectPicker
 	viewStatePicker
+	viewFilterPicker
 	viewSearch
 )
 
@@ -308,17 +318,18 @@ type Model struct {
 	commentIssue *Issue // which issue we're commenting on
 
 	// Comments cache for detail view
-	cachedComments   []Comment
-	cachedCommentID  string
+	cachedComments  []Comment
+	cachedCommentID string
 
 	// Detail viewport
 	detailViewport viewport.Model
 
 	// Help + spinner
-	help     help.Model
-	keys     keyMap
-	spinner  spinner.Model
-	loading  bool
+	help    help.Model
+	keys    keyMap
+	spinner      spinner.Model
+	loading      bool
+	loadingLabel string
 
 	// Launch menu + prompt editor
 	launchIssue *Issue
@@ -344,63 +355,65 @@ type Model struct {
 	stateForm      *huh.Form
 	stateIssue     *Issue
 
-	// Picker selection values (bound to huh forms via pointer)
-	pickerSelected string
+	// Filter picker
+	filterForm *huh.Form
 
 	// Server search
-	searchInput  textinput.Model
-	searching    bool
-	searchTerm   string
-	savedIssues  []Issue // stash regular issues while showing search results
+	searchInput textinput.Model
+	searching   bool
+	searchTerm  string
+	savedIssues []Issue // stash regular issues while showing search results
 }
 
 // keyMap defines keybindings for the help component.
 type keyMap struct {
-	Navigate key.Binding
-	Claude   key.Binding
-	Worktree key.Binding
-	Close    key.Binding
-	Comment  key.Binding
-	Detail   key.Binding
-	Filter   key.Binding
-	Open     key.Binding
-	Refresh  key.Binding
-	Search   key.Binding
-	Setup    key.Binding
-	Project  key.Binding
-	State    key.Binding
-	Assign   key.Binding
-	Quit     key.Binding
+	Navigate   key.Binding
+	Claude     key.Binding
+	Worktree   key.Binding
+	Close      key.Binding
+	Comment    key.Binding
+	Detail     key.Binding
+	Filter     key.Binding
+	FilterPick key.Binding
+	Open       key.Binding
+	Refresh    key.Binding
+	Search     key.Binding
+	Setup      key.Binding
+	Project    key.Binding
+	State      key.Binding
+	Assign     key.Binding
+	Quit       key.Binding
 }
 
 func defaultKeyMap() keyMap {
 	return keyMap{
-		Navigate: key.NewBinding(key.WithKeys("j", "k"), key.WithHelp("j/k", "navigate")),
-		Claude:   key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "claude+worktree")),
-		Worktree: key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "worktree")),
-		Close:    key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "close slot")),
-		Comment:  key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "comment")),
-		Detail:   key.NewBinding(key.WithKeys("d", "enter"), key.WithHelp("enter/d", "detail")),
-		Filter:   key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "filter")),
-		Open:     key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "open")),
-		Refresh:  key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
-		Search:   key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search")),
-		Setup:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "setup")),
-		Project:  key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "project")),
-		State:    key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "transition")),
-		Assign:   key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "assign to me")),
-		Quit:     key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
+		Navigate:   key.NewBinding(key.WithKeys("j", "k"), key.WithHelp("j/k", "navigate")),
+		Claude:     key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "claude+worktree")),
+		Worktree:   key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "worktree")),
+		Close:      key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "close slot")),
+		Comment:    key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "comment")),
+		Detail:     key.NewBinding(key.WithKeys("d", "enter"), key.WithHelp("enter/d", "detail")),
+		Filter:     key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "cycle filter")),
+		FilterPick: key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "filter picker")),
+		Open:       key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "open")),
+		Refresh:    key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
+		Search:     key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search")),
+		Setup:      key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "setup")),
+		Project:    key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "project")),
+		State:      key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "transition")),
+		Assign:     key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "assign to me")),
+		Quit:       key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
 	}
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Claude, k.Detail, k.Project, k.Filter, k.State, k.Assign, k.Quit}
+	return []key.Binding{k.Claude, k.Detail, k.Project, k.FilterPick, k.State, k.Assign, k.Quit}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Navigate, k.Claude, k.Worktree, k.Close},
-		{k.Comment, k.Detail, k.Filter, k.Search},
+		{k.Comment, k.Detail, k.Filter, k.FilterPick, k.Search},
 		{k.Project, k.State, k.Assign, k.Open},
 		{k.Refresh, k.Setup, k.Quit},
 	}
@@ -528,7 +541,11 @@ func (m Model) Init() tea.Cmd {
 func (m Model) fetchIssues() tea.Cmd {
 	return func() tea.Msg {
 		client := NewLinearClient(m.cfg.LinearAPIKey)
-		if m.projectFilter != nil && *m.projectFilter != "none" {
+		if m.projectFilter != nil {
+			if *m.projectFilter == "none" {
+				issues, _, err := client.GetIssuesWithNoProject(m.cfg.TeamID, m.filter, "")
+				return issuesLoadedMsg{issues: issues, err: err}
+			}
 			issues, _, err := client.GetIssuesByProject(m.cfg.TeamID, *m.projectFilter, "")
 			return issuesLoadedMsg{issues: issues, err: err}
 		}
@@ -710,6 +727,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateProjectPicker(msg)
 		case viewStatePicker:
 			return m.updateStatePicker(msg)
+		case viewFilterPicker:
+			return m.updateFilterPicker(msg)
 		case viewSearch:
 			return m.updateSearch(msg)
 		default:
@@ -720,6 +739,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.loading {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
+			m.statusMsg = m.spinner.View() + " " + m.loadingLabel
 			return m, cmd
 		}
 		return m, nil
@@ -732,6 +752,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.issues = msg.issues
 		m.rebuildList()
+		m.updateListTitle()
 		m.statusMsg = m.buildStatusLine()
 		return m, nil
 
@@ -907,6 +928,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, cmd
 	}
+	if m.view == viewFilterPicker && m.filterForm != nil {
+		form, cmd := m.filterForm.Update(msg)
+		if f, ok := form.(*huh.Form); ok {
+			m.filterForm = f
+		}
+		if m.filterForm.State == huh.StateCompleted {
+			return m.handleFilterSelected()
+		}
+		return m, cmd
+	}
 
 	var cmd tea.Cmd
 	m.list, cmd = m.list.Update(msg)
@@ -920,13 +951,17 @@ func (m *Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, key.NewBinding(key.WithKeys("tab"))):
 		m.filter = m.filter.Next()
+		m.updateListTitle()
 		m.loading = true
-		m.statusMsg = m.spinner.View() + " Loading..."
+		m.loadingLabel = "Loading..."
 		return m, tea.Batch(m.fetchIssues(), m.spinner.Tick)
+
+	case key.Matches(msg, key.NewBinding(key.WithKeys("f"))):
+		return m, m.showFilterPicker()
 
 	case key.Matches(msg, key.NewBinding(key.WithKeys("r"))):
 		m.loading = true
-		m.statusMsg = m.spinner.View() + " Refreshing..."
+		m.loadingLabel = "Refreshing..."
 		return m, tea.Batch(m.fetchIssues(), m.fetchWorktrees(), m.spinner.Tick)
 
 	case key.Matches(msg, key.NewBinding(key.WithKeys("c"))):
@@ -1387,6 +1422,8 @@ func (m Model) View() string {
 		return m.viewPicker("Select Project", m.projectForm)
 	case viewStatePicker:
 		return m.viewPicker("Transition State", m.stateForm)
+	case viewFilterPicker:
+		return m.viewPicker("Filter Issues", m.filterForm)
 	case viewSearch:
 		return m.viewSearchInput()
 	default:
@@ -1710,13 +1747,12 @@ func (m *Model) showProjectPicker() tea.Cmd {
 		options = append(options, huh.NewOption(label, p.ID))
 	}
 
-	m.pickerSelected = ""
 	m.projectForm = huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
+				Key("project").
 				Title("Filter by project").
-				Options(options...).
-				Value(&m.pickerSelected),
+				Options(options...),
 		),
 	).WithWidth(50).WithShowHelp(false).WithShowErrors(false)
 	m.view = viewProjectPicker
@@ -1733,13 +1769,12 @@ func (m *Model) showStatePicker() tea.Cmd {
 		options = append(options, huh.NewOption(label, s.ID))
 	}
 
-	m.pickerSelected = ""
 	m.stateForm = huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
+				Key("state").
 				Title(fmt.Sprintf("Transition %s", m.stateIssue.Identifier)).
-				Options(options...).
-				Value(&m.pickerSelected),
+				Options(options...),
 		),
 	).WithWidth(50).WithShowHelp(false).WithShowErrors(false)
 	m.view = viewStatePicker
@@ -1747,7 +1782,7 @@ func (m *Model) showStatePicker() tea.Cmd {
 }
 
 func (m *Model) handleProjectSelected() (tea.Model, tea.Cmd) {
-	selected := m.pickerSelected
+	selected := m.projectForm.GetString("project")
 	m.projectForm = nil
 	m.view = viewList
 
@@ -1771,20 +1806,23 @@ func (m *Model) handleProjectSelected() (tea.Model, tea.Cmd) {
 
 	m.updateListTitle()
 	m.loading = true
-	m.statusMsg = m.spinner.View() + " Loading..."
+	m.loadingLabel = "Loading..."
 	return m, tea.Batch(m.fetchIssues(), m.spinner.Tick)
 }
 
 func (m *Model) updateListTitle() {
+	title := m.cfg.TeamKey
 	if m.projectName != "" {
-		m.list.Title = fmt.Sprintf("%s > %s", m.cfg.TeamKey, m.projectName)
-	} else {
-		m.list.Title = m.cfg.TeamKey
+		title = fmt.Sprintf("%s > %s", m.cfg.TeamKey, m.projectName)
 	}
+	if m.filter != FilterAssigned {
+		title = fmt.Sprintf("%s [%s]", title, m.filter.String())
+	}
+	m.list.Title = title
 }
 
 func (m *Model) handleStateSelected() (tea.Model, tea.Cmd) {
-	selected := m.pickerSelected
+	selected := m.stateForm.GetString("state")
 	issue := m.stateIssue
 	m.stateForm = nil
 	m.stateIssue = nil
@@ -1795,6 +1833,72 @@ func (m *Model) handleStateSelected() (tea.Model, tea.Cmd) {
 		return m, m.changeStateCmd(issue.ID, selected, issue.Identifier)
 	}
 	return m, nil
+}
+
+func (m *Model) showFilterPicker() tea.Cmd {
+	options := []huh.Option[string]{
+		huh.NewOption("Assigned to me", "assigned"),
+		huh.NewOption("All issues", "all"),
+		huh.NewOption("Todo", "todo"),
+		huh.NewOption("In Progress", "inprogress"),
+		huh.NewOption("Unassigned", "unassigned"),
+	}
+
+	m.filterForm = huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Key("filter").
+				Title("Filter issues").
+				Options(options...),
+		),
+	).WithWidth(50).WithShowHelp(false).WithShowErrors(false)
+	m.view = viewFilterPicker
+	return m.filterForm.Init()
+}
+
+func (m *Model) handleFilterSelected() (tea.Model, tea.Cmd) {
+	selected := m.filterForm.GetString("filter")
+	m.filterForm = nil
+	m.view = viewList
+
+	switch selected {
+	case "assigned":
+		m.filter = FilterAssigned
+	case "all":
+		m.filter = FilterAll
+	case "todo":
+		m.filter = FilterTodo
+	case "inprogress":
+		m.filter = FilterInProgress
+	case "unassigned":
+		m.filter = FilterUnassigned
+	default:
+		return m, nil
+	}
+
+	m.updateListTitle()
+	m.loading = true
+	m.loadingLabel = "Loading..."
+	return m, tea.Batch(m.fetchIssues(), m.spinner.Tick)
+}
+
+func (m *Model) updateFilterPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "esc" {
+		m.view = viewList
+		m.filterForm = nil
+		return m, nil
+	}
+
+	form, cmd := m.filterForm.Update(msg)
+	if f, ok := form.(*huh.Form); ok {
+		m.filterForm = f
+	}
+
+	if m.filterForm.State == huh.StateCompleted {
+		return m.handleFilterSelected()
+	}
+
+	return m, cmd
 }
 
 func (m *Model) updateProjectPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -1862,7 +1966,7 @@ func (m *Model) updateSearch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.view = viewList
 		m.loading = true
-		m.statusMsg = m.spinner.View() + " Searching..."
+		m.loadingLabel = "Searching..."
 		return m, tea.Batch(m.searchIssuesCmd(term), m.spinner.Tick)
 	}
 


### PR DESCRIPTION
## Summary

- Add `FilterUnassigned` mode (`assignee: { null: true }`) so users can browse unassigned issues directly instead of hunting through "All"
- Fix broken "No project" picker filter that silently fell through to an unfiltered query
- Fix all huh form pickers (project, state, filter) using stale `Value()` pointers due to Bubble Tea's value-receiver copy semantics — switch to `Key()`/`GetString()` pattern
- Add filter picker (`f` key) using `huh.Form` for direct filter selection alongside existing Tab cycling
- Show assignee name and current filter mode in the list UI for better context
- Animate the loading spinner (was frozen on a single frame)
- Slim list GraphQL queries to only fetch fields needed for rendering — drops `description`, `relations`, `labels`, `timestamps`, `branchName`, `estimate` from list calls, keeping full field set for detail/search views
- Bump HTTP client timeout from 15s to 30s for broader queries

## Test plan

- [x] Launch app, verify default "Assigned to me" filter loads correctly
- [x] Press `Tab` to cycle through all 5 filters (Assigned, All, Todo, In Progress, Unassigned)
- [x] Press `f` to open filter picker, select each option, verify correct issues load
- [x] Press `p`, select "No project", verify only projectless issues appear
- [x] Verify assignee name shows in list item descriptions
- [x] Verify list title updates to show non-default filter (e.g. `TSCODE [Unassigned]`)
- [x] Verify spinner animates during loading
- [x] Verify issue detail view (`d`/`Enter`) still shows full info (description, labels, relations)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unassigned filter and filter picker UI to issue list
> - Adds a new `FilterUnassigned` mode that queries issues where assignee is null, excluding completed/cancelled states via a new `GetIssuesWithNoProject` method in [linear.go](https://github.com/serabi/linear-worktree/pull/2/files#diff-daf8df21e1a0fe44d60103b60c2d49b7d070ac15de7640ce3a3ed71d4b03bea6).
> - Adds a form-based filter picker (bound to `f`) in [model.go](https://github.com/serabi/linear-worktree/pull/2/files#diff-5b0177864e946f50ded814588776996128f6b96cbaec3d79877d7163102bb2c1) alongside the existing tab-cycling filter; the list title now shows the active non-default filter in brackets.
> - Issue list items now display the assignee name or
>
> #### 🖇️ Linked Issues
> Unassigned
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78b6db6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->