### PR TITLE
Show Linear API key link during onboarding

### DIFF
--- a/model_settings.go
+++ b/model_settings.go
@@ -59,7 +59,7 @@ func (m *Model) buildTab(index, w int) *huh.Form {
 			huh.NewGroup(
 				huh.NewInput().
 					Title("Linear API Key").
-					Description("Personal API key from Linear Settings > API. Stored securely in your OS keychain, never written to the config file.").
+					Description("Create one at: https://linear.app/settings\nGo to Account > Security & access > API Keys. Stored in your OS keychain.\nPress ctrl+w to open in browser.").
 					Placeholder("lin_api_...").
 					EchoMode(huh.EchoModePassword).
 					Value(&m.settingsDraft.apiKey),
@@ -275,6 +275,11 @@ func (m *Model) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "3":
 		m.settingsActiveTab = 2
 		return m, nil
+	case "ctrl+w":
+		if m.settingsActiveTab == 0 {
+			openBrowser("https://linear.app/settings")
+			return m, nil
+		}
 	case "ctrl+s":
 		for _, tab := range m.settingsTabs {
 			if tab != nil && tab.State == huh.StateNormal {


### PR DESCRIPTION
## Summary

- Update the API key field description in settings to include a direct URL to Linear settings and navigation instructions (Account > Security & access > API Keys)
- Add `ctrl+w` shortcut on the Credentials tab to open Linear settings in the browser

Closes #6

## Test plan

- [x] Run `./linear-worktree --demo`, press `s` — verify updated description on Credentials tab
- [x] Press `ctrl+w` on Credentials tab — verify Linear settings opens in browser
- [x] Confirm `ctrl+w` does nothing on other settings tabs
- [x] `go test ./...` passes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show Linear API key link and browser shortcut during onboarding
> - Updates the 'Linear API Key' field description in [model_settings.go](https://github.com/serabi/linear-worktree/pull/27/files#diff-57e66c935653d93e3ca69aeae6c7469b1f534af24e5e7120165dde684fab377b) to include the settings URL, step-by-step path, and a hint that `ctrl+w` opens it in a browser.
> - Adds `ctrl+w` key handling: when on the first settings tab, pressing `ctrl+w` opens `https://linear.app/settings` in the default browser.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8edf8f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->