### PR TITLE
fix(settings): show correct footer hint during first-run setup

### DIFF
--- a/model_view.go
+++ b/model_view.go
@@ -274,7 +274,13 @@ func (m Model) viewSettings() string {
 	header := titleStyle.Render("Settings")
 	tabBar := m.renderSettingsTabBar()
 	body := m.activeSettingsForm().View()
-	help := statusBarStyle.Render("Tab: next field  Enter: save  1/2/3: switch tab  Esc: cancel")
+	helpText := "Tab: next field  Enter: save  1/2/3: switch tab"
+	if m.settingsFirstRun {
+		helpText += "  (complete setup to continue)"
+	} else {
+		helpText += "  Esc: cancel"
+	}
+	help := statusBarStyle.Render(helpText)
 	return appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, header, tabBar, "", body, "", help))
 }
 

--- a/testdata/golden/settings_first_run.txt
+++ b/testdata/golden/settings_first_run.txt
@@ -12,4 +12,4 @@ Settings
    Add multiple teams separated by commas. First team is your default. Press 1-9 from the issue   
    list to switch between teams.                                                                  
                                                                                                   
-  Tab: next field  Enter: save  1/2/3: switch tab  Esc: cancel
+  Tab: next field  Enter: save  1/2/3: switch tab  (complete setup to continue)


### PR DESCRIPTION
## Summary

- During first-run settings, the footer showed "Esc: cancel" even though Esc was blocked — now shows "(complete setup to continue)" instead
- Updated golden snapshot to match

Closes #35

## Test plan

- [x] `go test ./...` passes
- [ ] Run `./linear-worktree` with no config to trigger first-run — verify footer says "(complete setup to continue)"
- [ ] Run settings from normal mode (`s` key) — verify footer still says "Esc: cancel"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced status bar guidance in settings. Help text now dynamically adapts based on setup progress. During initial configuration, users see "(complete setup to continue)" to guide them through setup. After completion, the full set of navigation options, including the escape key instruction, becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->