### PR TITLE
feat(worktree): management, cleanup, and hook error propagation

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -283,15 +283,7 @@ func cmuxIdentify() (*cmuxIdentifyResult, error) {
 // OpenSlot adds an issue to the next available slot, creates a pane, and launches Claude.
 // Uses the default prompt built from the issue.
 func (pm *PaneManager) OpenSlot(issue Issue, wtPath string, cfg Config) (*WorktreeSlot, error) {
-	prompt := fmt.Sprintf("You're working on %s: %s", issue.Identifier, issue.Title)
-	if issue.Description != "" {
-		desc := issue.Description
-		if len(desc) > 500 {
-			desc = desc[:500] + "..."
-		}
-		prompt += fmt.Sprintf("\n\nDescription:\n%s", desc)
-	}
-	return pm.OpenSlotWithPrompt(issue, wtPath, prompt, cfg)
+	return pm.OpenSlotWithPrompt(issue, wtPath, buildPrompt(issue, cfg), cfg)
 }
 
 // OpenSlotWithPrompt adds an issue to the next available slot with a custom prompt.
@@ -449,6 +441,19 @@ func (pm *PaneManager) Slots() [absoluteMaxSlots]*WorktreeSlot {
 	return pm.slots
 }
 
+// FindSlotByIdentifier returns the slot and its index for the given issue identifier.
+// Returns nil, -1 if no slot matches.
+func (pm *PaneManager) FindSlotByIdentifier(identifier string) (*WorktreeSlot, int) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	for i, slot := range pm.slots {
+		if slot != nil && slot.Issue.Identifier == identifier {
+			return slot, i
+		}
+	}
+	return nil, -1
+}
+
 // ActiveCount returns how many slots are occupied.
 func (pm *PaneManager) ActiveCount() int {
 	pm.mu.RLock()
@@ -587,20 +592,7 @@ func inferStatus(terminalText string) AgentStatus {
 
 func containsAny(s string, substrs ...string) bool {
 	for _, sub := range substrs {
-		if contains(s, sub) {
-			return true
-		}
-	}
-	return false
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
+		if strings.Contains(s, sub) {
 			return true
 		}
 	}
@@ -627,9 +619,3 @@ func shellQuote(s string) string {
 	return string(result)
 }
 
-// escapeShell is kept for backward compat in tests; prefer shellQuote for new code.
-func escapeShell(s string) string {
-	inner := shellQuote(s)
-	// Strip the outer quotes to match the old API (caller wraps in quotes)
-	return inner[1 : len(inner)-1]
-}

--- a/cmux_test.go
+++ b/cmux_test.go
@@ -94,25 +94,6 @@ func TestInferStatus(t *testing.T) {
 	}
 }
 
-func TestEscapeShell(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"hello", "hello"},
-		{"it's a test", "it'\\''s a test"},
-		{"no quotes here", "no quotes here"},
-		{"", ""},
-	}
-
-	for _, tt := range tests {
-		result := escapeShell(tt.input)
-		if result != tt.expected {
-			t.Errorf("escapeShell(%q) = %q, want %q", tt.input, result, tt.expected)
-		}
-	}
-}
-
 func TestShellQuote(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/model.go
+++ b/model.go
@@ -77,6 +77,17 @@ func NewModel(cfg Config) Model {
 	lnk.SetFilteringEnabled(false)
 	lnk.Styles.Title = titleStyle
 
+	wtDelegate := list.NewDefaultDelegate()
+	wtDelegate.ShowDescription = true
+	wtDelegate.SetHeight(2)
+	wtDelegate.SetSpacing(0)
+	wtl := list.New([]list.Item{}, wtDelegate, 0, 0)
+	wtl.Title = "Worktrees"
+	wtl.SetShowHelp(false)
+	wtl.SetShowStatusBar(false)
+	wtl.SetFilteringEnabled(true)
+	wtl.Styles.Title = titleStyle
+
 	ta := textarea.New()
 	ta.Placeholder = "Enter your prompt for Claude..."
 	ta.CharLimit = 10000
@@ -98,6 +109,7 @@ func NewModel(cfg Config) Model {
 		detailViewport:   vp,
 		launchList:       ll,
 		linkList:         lnk,
+		worktreeList:     wtl,
 		promptArea:       ta,
 		teamCache:        make(map[string]*teamState),
 	}

--- a/model_commands.go
+++ b/model_commands.go
@@ -213,10 +213,25 @@ func (m Model) launchWithPromptCmd(issue Issue, prompt string) tea.Cmd {
 		if err != nil {
 			return worktreeCreatedMsg{err: err, identifier: issue.Identifier}
 		}
-		if err := RunPostCreateHook(wtPath, m.cfg); err != nil {
-			debugLog.Printf("post-create hook failed: %v", err)
+		hookErr := RunPostCreateHook(wtPath, m.cfg)
+		if hookErr != nil {
+			debugLog.Printf("post-create hook failed: %v", hookErr)
 		}
-		return launchReadyMsg{issue: issue, wtPath: wtPath, prompt: prompt}
+		return launchReadyMsg{issue: issue, wtPath: wtPath, prompt: prompt, hookErr: hookErr}
+	}
+}
+
+func (m Model) fetchWorktreeListCmd() tea.Cmd {
+	return func() tea.Msg {
+		wts, err := ListWorktrees()
+		return worktreeListLoadedMsg{worktrees: wts, err: err}
+	}
+}
+
+func (m Model) removeWorktreeCmd(identifier, wtPath string) tea.Cmd {
+	return func() tea.Msg {
+		err := RemoveWorktree(wtPath)
+		return worktreeRemovedMsg{identifier: identifier, err: err}
 	}
 }
 

--- a/model_detail.go
+++ b/model_detail.go
@@ -176,6 +176,26 @@ func (m Model) writeDetailMetadata(b *strings.Builder, issue *Issue, ctx detailR
 	if issue.BranchName != "" {
 		b.WriteString(ctx.field("Branch", lipgloss.NewStyle().Foreground(greenColor).Render(issue.BranchName)))
 	}
+	if m.hasWorktree(issue.Identifier) {
+		wtStatus := worktreeMarker.Render("active")
+		if m.paneManager != nil {
+			if slot, _ := m.paneManager.FindSlotByIdentifier(issue.Identifier); slot != nil {
+				var style lipgloss.Style
+				switch slot.Status {
+				case AgentRunning:
+					style = slotRunningStyle
+				case AgentWaiting:
+					style = slotWaitingStyle
+				case AgentIdle:
+					style = slotIdleStyle
+				default:
+					style = slotEmptyStyle
+				}
+				wtStatus += " " + style.Render(fmt.Sprintf("[slot %d: %s]", slot.Index+1, slot.Status.Label()))
+			}
+		}
+		b.WriteString(ctx.field("Worktree", wtStatus))
+	}
 	if issue.URL != "" {
 		b.WriteString(ctx.field("URL", ctx.link(issue.URL)))
 	}

--- a/model_items.go
+++ b/model_items.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+)
+
+type issueItem struct {
+	issue       Issue
+	hasWorktree bool
+	slotIdx     int
+	slotStatus  AgentStatus
+}
+
+func (i issueItem) Title() string {
+	icon := statusIcon(i.issue.State.Type)
+	pri := priorityIcon(i.issue.Priority)
+	wt := ""
+	if i.hasWorktree {
+		wt = worktreeMarker.Render(" 🌳")
+	}
+
+	slot := ""
+	if i.slotIdx >= 0 {
+		var style lipgloss.Style
+		switch i.slotStatus {
+		case AgentRunning:
+			style = slotRunningStyle
+		case AgentWaiting:
+			style = slotWaitingStyle
+		case AgentIdle:
+			style = slotIdleStyle
+		default:
+			style = slotEmptyStyle
+		}
+		slot = style.Render(fmt.Sprintf(" [%d:%s]", i.slotIdx+1, i.slotStatus.String()))
+	}
+
+	return fmt.Sprintf("%s %s %s %s%s%s",
+		icon, pri,
+		issueIdentStyle.Render(i.issue.Identifier),
+		i.issue.Title, wt, slot,
+	)
+}
+
+func (i issueItem) Description() string {
+	var parts []string
+	if i.issue.Assignee != nil {
+		name := i.issue.Assignee.DisplayName
+		if name == "" {
+			name = i.issue.Assignee.Name
+		}
+		if idx := strings.IndexByte(name, ' '); idx > 0 {
+			name = name[:idx]
+		}
+		parts = append(parts, name)
+	} else {
+		parts = append(parts, commentDimStyle.Render("unassigned"))
+	}
+
+	if i.issue.Project != nil {
+		parts = append(parts, i.issue.Project.Name)
+	}
+
+	if i.issue.DueDate != nil {
+		if t, err := time.Parse("2006-01-02", *i.issue.DueDate); err == nil {
+			days := int(time.Until(t).Hours() / 24)
+			switch {
+			case days < 0:
+				parts = append(parts, fmt.Sprintf("OVERDUE %dd", -days))
+			case days <= 3:
+				parts = append(parts, fmt.Sprintf("Due in %dd", days))
+			}
+		}
+	}
+
+	if i.issue.SLABreachesAt != nil {
+		if t, err := time.Parse(time.RFC3339, *i.issue.SLABreachesAt); err == nil {
+			d := time.Until(t)
+			var slaStr string
+			switch {
+			case d < 0:
+				slaStr = lipgloss.NewStyle().Foreground(redColor).Render("SLA BREACHED")
+			case d <= 24*time.Hour:
+				slaStr = lipgloss.NewStyle().Foreground(redColor).Render(fmt.Sprintf("SLA %dh", int(d.Hours())))
+			case d <= 3*24*time.Hour:
+				slaStr = lipgloss.NewStyle().Foreground(orangeColor).Render(fmt.Sprintf("SLA %dd", int(d.Hours()/24)))
+			default:
+				slaStr = commentDimStyle.Render(fmt.Sprintf("SLA %dd", int(d.Hours()/24)))
+			}
+			parts = append(parts, slaStr)
+		}
+	}
+
+	if n := len(i.issue.Children.Nodes); n > 0 {
+		done := 0
+		for _, c := range i.issue.Children.Nodes {
+			if c.State.Type == "completed" {
+				done++
+			}
+		}
+		parts = append(parts, fmt.Sprintf("[%d/%d]", done, n))
+	}
+
+	if labels := i.issue.Labels.Nodes; len(labels) > 0 {
+		maxLabels := 2
+		if len(labels) < maxLabels {
+			maxLabels = len(labels)
+		}
+		for _, l := range labels[:maxLabels] {
+			style := lipgloss.NewStyle().Foreground(lipgloss.Color(l.Color))
+			parts = append(parts, style.Render(l.Name))
+		}
+		if remaining := len(labels) - maxLabels; remaining > 0 {
+			parts = append(parts, commentDimStyle.Render(fmt.Sprintf("+%d", remaining)))
+		}
+	}
+
+	return strings.Join(parts, " | ")
+}
+
+func (i issueItem) FilterValue() string {
+	return i.issue.Identifier + " " + i.issue.Title
+}
+
+type launchOption struct {
+	action    string
+	title     string
+	desc      string
+	slotIndex int
+}
+
+func (l launchOption) Title() string       { return l.title }
+func (l launchOption) Description() string { return l.desc }
+func (l launchOption) FilterValue() string { return l.title }
+
+type linkItem struct {
+	label   string
+	value   string
+	isIssue bool
+}
+
+func (l linkItem) Title() string       { return l.label }
+func (l linkItem) Description() string { return "" }
+func (l linkItem) FilterValue() string { return l.label }
+
+type worktreeItem struct {
+	path       string
+	branch     string
+	head       string
+	identifier string
+	slotIdx    int
+	slotStatus AgentStatus
+}
+
+func (w worktreeItem) Title() string {
+	slot := ""
+	if w.slotIdx >= 0 {
+		var style lipgloss.Style
+		switch w.slotStatus {
+		case AgentRunning:
+			style = slotRunningStyle
+		case AgentWaiting:
+			style = slotWaitingStyle
+		case AgentIdle:
+			style = slotIdleStyle
+		default:
+			style = slotEmptyStyle
+		}
+		slot = style.Render(fmt.Sprintf(" [%d:%s]", w.slotIdx+1, w.slotStatus.String()))
+	}
+	ident := ""
+	if w.identifier != "" {
+		ident = issueIdentStyle.Render(w.identifier) + " "
+	}
+	return fmt.Sprintf("%s%s%s", ident, w.branch, slot)
+}
+
+func (w worktreeItem) Description() string {
+	short := w.head
+	if len(short) > 8 {
+		short = short[:8]
+	}
+	return fmt.Sprintf("%s  %s", short, w.path)
+}
+
+func (w worktreeItem) FilterValue() string {
+	return w.branch + " " + w.identifier + " " + w.path
+}
+
+type worktreeSeparator struct {
+	label string
+}
+
+func (w worktreeSeparator) Title() string       { return commentDimStyle.Render("── " + w.label + " ──") }
+func (w worktreeSeparator) Description() string { return "" }
+func (w worktreeSeparator) FilterValue() string { return "" }
+
+func statusIcon(stateType string) string {
+	switch stateType {
+	case "backlog":
+		return lipgloss.NewStyle().Foreground(subtleColor).Render("○")
+	case "unstarted":
+		return lipgloss.NewStyle().Foreground(dimColor).Render("○")
+	case "started":
+		return lipgloss.NewStyle().Foreground(yellowColor).Render("●")
+	case "completed":
+		return lipgloss.NewStyle().Foreground(greenColor).Render("✓")
+	case "cancelled":
+		return lipgloss.NewStyle().Foreground(mutedColor).Render("✗")
+	default:
+		return "?"
+	}
+}
+
+func priorityIcon(p int) string {
+	switch p {
+	case 1:
+		return urgentStyle.Render("▲")
+	case 2:
+		return highStyle.Render("▲")
+	case 3:
+		return mediumStyle.Render("■")
+	case 4:
+		return lowStyle.Render("▼")
+	default:
+		return " "
+	}
+}

--- a/model_list_actions.go
+++ b/model_list_actions.go
@@ -51,30 +51,23 @@ func (m Model) buildLaunchOptions(issue *Issue) []list.Item {
 	}
 
 	if m.paneManager != nil {
-		for _, slot := range m.paneManager.Slots() {
-			if slot != nil && slot.Issue.Identifier == issue.Identifier {
-				items = append([]list.Item{
-					launchOption{
-						"resume",
-						"Resume existing session",
-						fmt.Sprintf("Focus slot %d (%s)", slot.Index+1, slot.Status.Label()),
-						slot.Index,
-					},
-				}, items...)
-				break
-			}
+		if slot, _ := m.paneManager.FindSlotByIdentifier(issue.Identifier); slot != nil {
+			items = append([]list.Item{
+				launchOption{
+					"resume",
+					"Resume existing session",
+					fmt.Sprintf("Focus slot %d (%s)", slot.Index+1, slot.Status.Label()),
+					slot.Index,
+				},
+			}, items...)
 		}
 	}
 
-	branch := m.cfg.BranchPrefix + strings.ToLower(issue.Identifier)
-	hasWorktree := m.worktreeBranches[branch]
+	hasWorktree := m.hasWorktree(issue.Identifier)
 	hasSlot := false
 	if m.paneManager != nil {
-		for _, slot := range m.paneManager.Slots() {
-			if slot != nil && slot.Issue.Identifier == issue.Identifier {
-				hasSlot = true
-				break
-			}
+		if s, _ := m.paneManager.FindSlotByIdentifier(issue.Identifier); s != nil {
+			hasSlot = true
 		}
 	}
 	if hasWorktree && !hasSlot {
@@ -102,31 +95,94 @@ func (m *Model) createSelectedWorktree() (tea.Model, tea.Cmd) {
 	}
 }
 
-func (m *Model) closeSelectedSlot() (tea.Model, tea.Cmd) {
-	if m.paneManager == nil {
-		m.statusMsg = "No cmux panes to close"
-		return m, nil
-	}
-
-	issue := m.selectedIssue()
-	if issue == nil {
-		return m, nil
-	}
-
-	for i, slot := range m.paneManager.Slots() {
-		if slot != nil && slot.Issue.Identifier == issue.Identifier {
-			if err := m.paneManager.CloseSlot(i); err != nil {
-				m.statusMsg = fmt.Sprintf("Error closing slot: %v", err)
-			} else {
-				m.statusMsg = fmt.Sprintf("Closed slot %d (%s)", i+1, issue.Identifier)
-				m.rebuildList()
+func (m *Model) buildWorktreeListItems(worktrees []Worktree) []list.Item {
+	slotMap := make(map[string]*WorktreeSlot)
+	if m.paneManager != nil {
+		for _, slot := range m.paneManager.Slots() {
+			if slot != nil {
+				slotMap[slot.WorktreePath] = slot
 			}
-			return m, nil
 		}
 	}
 
-	m.statusMsg = fmt.Sprintf("%s is not in a slot", issue.Identifier)
-	return m, nil
+	var managed, other []list.Item
+	for _, wt := range worktrees {
+		if wt.Bare {
+			continue
+		}
+		identifier := ""
+		if strings.HasPrefix(wt.Branch, m.cfg.BranchPrefix) {
+			identifier = strings.ToUpper(strings.TrimPrefix(wt.Branch, m.cfg.BranchPrefix))
+		}
+
+		item := worktreeItem{
+			path:       wt.Path,
+			branch:     wt.Branch,
+			head:       wt.Head,
+			identifier: identifier,
+			slotIdx:    -1,
+		}
+
+		if slot, ok := slotMap[wt.Path]; ok {
+			item.slotIdx = slot.Index
+			item.slotStatus = slot.Status
+		}
+
+		if identifier != "" {
+			managed = append(managed, item)
+		} else {
+			other = append(other, item)
+		}
+	}
+
+	items := managed
+	if len(other) > 0 {
+		items = append(items, worktreeSeparator{label: fmt.Sprintf("Other worktrees (%d)", len(other))})
+		items = append(items, other...)
+	}
+	return items
+}
+
+func (m *Model) findWorktreePath(identifier string) string {
+	branch := m.getBranchName(identifier)
+	wts, err := ListWorktrees()
+	if err != nil {
+		return ""
+	}
+	for _, wt := range wts {
+		if wt.Branch == branch {
+			return wt.Path
+		}
+	}
+	return ""
+}
+
+func (m *Model) removeSelectedWorktree() (tea.Model, tea.Cmd) {
+	issue := m.selectedIssue()
+	if issue == nil {
+		m.statusMsg = "No issue selected"
+		return m, nil
+	}
+
+	if !m.hasWorktree(issue.Identifier) {
+		m.statusMsg = fmt.Sprintf("%s has no worktree", issue.Identifier)
+		return m, nil
+	}
+
+	if m.paneManager != nil {
+		if _, idx := m.paneManager.FindSlotByIdentifier(issue.Identifier); idx >= 0 {
+			_ = m.paneManager.CloseSlot(idx)
+		}
+	}
+
+	wtPath := m.findWorktreePath(issue.Identifier)
+	if wtPath == "" {
+		m.statusMsg = fmt.Sprintf("Could not find worktree path for %s", issue.Identifier)
+		return m, nil
+	}
+
+	m.statusMsg = fmt.Sprintf("Removing worktree for %s...", issue.Identifier)
+	return m, m.removeWorktreeCmd(issue.Identifier, wtPath)
 }
 
 func (m *Model) showSelectedIssueDetail() (tea.Model, tea.Cmd) {

--- a/model_list_actions.go
+++ b/model_list_actions.go
@@ -169,16 +169,16 @@ func (m *Model) removeSelectedWorktree() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if m.paneManager != nil {
-		if _, idx := m.paneManager.FindSlotByIdentifier(issue.Identifier); idx >= 0 {
-			_ = m.paneManager.CloseSlot(idx)
-		}
-	}
-
 	wtPath := m.findWorktreePath(issue.Identifier)
 	if wtPath == "" {
 		m.statusMsg = fmt.Sprintf("Could not find worktree path for %s", issue.Identifier)
 		return m, nil
+	}
+
+	if m.paneManager != nil {
+		if _, idx := m.paneManager.FindSlotByIdentifier(issue.Identifier); idx >= 0 {
+			_ = m.paneManager.CloseSlot(idx)
+		}
 	}
 
 	m.statusMsg = fmt.Sprintf("Removing worktree for %s...", issue.Identifier)

--- a/model_messages.go
+++ b/model_messages.go
@@ -1,0 +1,125 @@
+package main
+
+type issuesLoadedMsg struct {
+	issues []Issue
+	err    error
+}
+
+type worktreesLoadedMsg struct {
+	branches map[string]bool
+}
+
+type worktreeCreatedMsg struct {
+	path       string
+	identifier string
+	err        error
+	hookErr    error
+}
+
+type claudeLaunchedMsg struct {
+	identifier string
+	err        error
+}
+
+type cmuxSlotOpenedMsg struct {
+	slotIdx    int
+	identifier string
+	wtPath     string
+	err        error
+}
+
+type teamsLoadedMsg struct {
+	err error
+}
+
+type setupCompleteMsg struct {
+	cfg Config
+}
+
+type commentPostedMsg struct {
+	identifier string
+	err        error
+}
+
+type commentsLoadedMsg struct {
+	issueID  string
+	comments []Comment
+	err      error
+}
+
+type launchReadyMsg struct {
+	issue   Issue
+	wtPath  string
+	prompt  string
+	hookErr error
+}
+
+type statusPollMsg struct{}
+
+type viewerLoadedMsg struct {
+	viewer *Viewer
+	err    error
+}
+
+type projectsLoadedMsg struct {
+	projects []Project
+	err      error
+}
+
+type statesLoadedMsg struct {
+	states []WorkflowState
+	err    error
+}
+
+type issueAssignedMsg struct {
+	identifier string
+	err        error
+}
+
+type issueUnassignedMsg struct {
+	identifier string
+	err        error
+}
+
+type issueStateChangedMsg struct {
+	identifier string
+	err        error
+}
+
+type branchIssueFoundMsg struct {
+	issue *Issue
+}
+
+type issueNavigatedMsg struct {
+	issue *Issue
+	err   error
+}
+
+type detailContentMsg struct {
+	issueID string
+	content string
+}
+
+type searchResultsMsg struct {
+	issues []Issue
+	err    error
+}
+
+type prefetchTickMsg struct {
+	seq int
+}
+
+type teamSwitchedMsg struct {
+	cfg Config
+	err error
+}
+
+type worktreeRemovedMsg struct {
+	identifier string
+	err        error
+}
+
+type worktreeListLoadedMsg struct {
+	worktrees []Worktree
+	err       error
+}

--- a/model_pickers.go
+++ b/model_pickers.go
@@ -365,6 +365,71 @@ func (m *Model) updateStatePicker(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m *Model) updateWorktreeList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.view = viewList
+		return m, nil
+
+	case "enter":
+		item := m.worktreeList.SelectedItem()
+		if item == nil {
+			return m, nil
+		}
+		wi, ok := item.(worktreeItem)
+		if !ok {
+			return m, nil
+		}
+		if wi.identifier != "" {
+			for _, issue := range m.issues {
+				if strings.EqualFold(issue.Identifier, wi.identifier) {
+					m.view = viewDetail
+					m.detailIssue = &issue
+					m.detailHistory = nil
+					m.detailViewport.SetWidth(m.width - 6)
+					m.detailViewport.SetHeight(m.height - 6)
+					m.loading = true
+					m.loadingLabel = "Loading..."
+					cmds := []tea.Cmd{m.buildDetailContentCmd(&issue), m.spinner.Tick}
+					if issue.ID != m.cachedCommentID {
+						cmds = append(cmds, m.fetchCommentsCmd(issue.ID))
+					}
+					return m, tea.Batch(cmds...)
+				}
+			}
+			m.statusMsg = fmt.Sprintf("Issue %s not in current list", wi.identifier)
+		}
+		return m, nil
+
+	case "x":
+		item := m.worktreeList.SelectedItem()
+		if item == nil {
+			return m, nil
+		}
+		wi, ok := item.(worktreeItem)
+		if !ok {
+			return m, nil
+		}
+		m.confirm = &confirmDialog{
+			action:  confirmRemoveWorktree,
+			title:   "Remove Worktree?",
+			message: fmt.Sprintf("Remove worktree and branch %s? This cannot be undone.", wi.branch),
+			onYes: func(m *Model) (tea.Model, tea.Cmd) {
+				if wi.slotIdx >= 0 && m.paneManager != nil {
+					_ = m.paneManager.CloseSlot(wi.slotIdx)
+				}
+				m.statusMsg = fmt.Sprintf("Removing %s...", wi.branch)
+				return m, m.removeWorktreeCmd(wi.identifier, wi.path)
+			},
+		}
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	m.worktreeList, cmd = m.worktreeList.Update(msg)
+	return m, cmd
+}
+
 func (m *Model) showLinkList(items []list.Item, title string) {
 	m.linkList.Title = title
 	m.linkList.SetItems(items)

--- a/model_settings.go
+++ b/model_settings.go
@@ -150,10 +150,8 @@ func (m *Model) recreatePaneManagerIfNeeded() {
 	if m.paneManager == nil || m.paneManager.maxSlots == m.cfg.MaxSlots {
 		return
 	}
-	for i, slot := range m.paneManager.Slots() {
-		if slot != nil {
-			_ = m.paneManager.CloseSlot(i)
-		}
+	for i := range m.paneManager.Slots() {
+		_ = m.paneManager.CloseSlot(i)
 	}
 	m.paneManager = NewPaneManager(m.cmuxClient, m.cfg.MaxSlots)
 }

--- a/model_state.go
+++ b/model_state.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
@@ -14,359 +13,7 @@ import (
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2"
-	"charm.land/lipgloss/v2"
-	"charm.land/lipgloss/v2/compat"
 )
-
-var (
-	// Adaptive colors for light/dark terminal themes.
-	// AdaptiveColor: {Light, Dark}
-	// Adaptive colors for WCAG AA contrast on both light and dark backgrounds.
-	// Light values target >= 4.5:1 against #F5F5F5; dark values target visibility on #1E1E1E.
-	dimColor       = compat.AdaptiveColor{Light: lipgloss.Color("#444"), Dark: lipgloss.Color("#888")}
-	subtleColor    = compat.AdaptiveColor{Light: lipgloss.Color("#555"), Dark: lipgloss.Color("#555")}
-	mutedColor     = compat.AdaptiveColor{Light: lipgloss.Color("#555"), Dark: lipgloss.Color("#666")}
-	faintColor     = compat.AdaptiveColor{Light: lipgloss.Color("#646464"), Dark: lipgloss.Color("#444")}
-	yellowColor    = compat.AdaptiveColor{Light: lipgloss.Color("#B45309"), Dark: lipgloss.Color("#EAB308")}
-	identCyanColor = compat.AdaptiveColor{Light: lipgloss.Color("#0E7490"), Dark: lipgloss.Color("#06B6D4")}
-	greenColor     = compat.AdaptiveColor{Light: lipgloss.Color("#15803D"), Dark: lipgloss.Color("#22C55E")}
-	redColor       = compat.AdaptiveColor{Light: lipgloss.Color("#B91C1C"), Dark: lipgloss.Color("#EF4444")}
-	orangeColor    = compat.AdaptiveColor{Light: lipgloss.Color("#C2410C"), Dark: lipgloss.Color("#F97316")}
-	blueColor      = compat.AdaptiveColor{Light: lipgloss.Color("#2563EB"), Dark: lipgloss.Color("#3B82F6")}
-
-	appStyle = lipgloss.NewStyle().Padding(0, 1)
-
-	titleStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("#7C3AED")).
-			Padding(0, 1)
-
-	statusBarStyle = lipgloss.NewStyle().
-			Foreground(dimColor).
-			Padding(0, 1)
-
-	issueIdentStyle = lipgloss.NewStyle().
-			Foreground(identCyanColor).
-			Bold(true)
-
-	worktreeMarker = lipgloss.NewStyle().
-			Foreground(greenColor)
-
-	urgentStyle = lipgloss.NewStyle().Foreground(redColor)
-	highStyle   = lipgloss.NewStyle().Foreground(orangeColor)
-	mediumStyle = lipgloss.NewStyle().Foreground(yellowColor)
-	lowStyle    = lipgloss.NewStyle().Foreground(blueColor)
-
-	setupStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#7C3AED")).
-			Padding(1, 2).
-			Width(50)
-
-	slotRunningStyle = lipgloss.NewStyle().Foreground(greenColor)
-	slotWaitingStyle = lipgloss.NewStyle().Foreground(yellowColor)
-	slotIdleStyle    = lipgloss.NewStyle().Foreground(dimColor)
-	slotEmptyStyle   = lipgloss.NewStyle().Foreground(faintColor)
-
-	commentDimStyle = lipgloss.NewStyle().Foreground(dimColor)
-
-	activeTabStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("#7C3AED")).
-			Border(lipgloss.NormalBorder(), false, false, true, false).
-			BorderForeground(lipgloss.Color("#7C3AED")).
-			Padding(0, 2)
-
-	inactiveTabStyle = lipgloss.NewStyle().
-				Foreground(dimColor).
-				Border(lipgloss.NormalBorder(), false, false, true, false).
-				BorderForeground(faintColor).
-				Padding(0, 2)
-)
-
-type issueItem struct {
-	issue       Issue
-	hasWorktree bool
-	slotIdx     int
-	slotStatus  AgentStatus
-}
-
-func (i issueItem) Title() string {
-	icon := statusIcon(i.issue.State.Type)
-	pri := priorityIcon(i.issue.Priority)
-	wt := ""
-	if i.hasWorktree {
-		wt = worktreeMarker.Render(" 🌳")
-	}
-
-	slot := ""
-	if i.slotIdx >= 0 {
-		var style lipgloss.Style
-		switch i.slotStatus {
-		case AgentRunning:
-			style = slotRunningStyle
-		case AgentWaiting:
-			style = slotWaitingStyle
-		case AgentIdle:
-			style = slotIdleStyle
-		default:
-			style = slotEmptyStyle
-		}
-		slot = style.Render(fmt.Sprintf(" [%d:%s]", i.slotIdx+1, i.slotStatus.String()))
-	}
-
-	return fmt.Sprintf("%s %s %s %s%s%s",
-		icon, pri,
-		issueIdentStyle.Render(i.issue.Identifier),
-		i.issue.Title, wt, slot,
-	)
-}
-
-func (i issueItem) Description() string {
-	var parts []string
-	if i.issue.Assignee != nil {
-		name := i.issue.Assignee.DisplayName
-		if name == "" {
-			name = i.issue.Assignee.Name
-		}
-		if idx := strings.IndexByte(name, ' '); idx > 0 {
-			name = name[:idx]
-		}
-		parts = append(parts, name)
-	} else {
-		parts = append(parts, commentDimStyle.Render("unassigned"))
-	}
-
-	if i.issue.Project != nil {
-		parts = append(parts, i.issue.Project.Name)
-	}
-
-	if i.issue.DueDate != nil {
-		if t, err := time.Parse("2006-01-02", *i.issue.DueDate); err == nil {
-			days := int(time.Until(t).Hours() / 24)
-			switch {
-			case days < 0:
-				parts = append(parts, fmt.Sprintf("OVERDUE %dd", -days))
-			case days <= 3:
-				parts = append(parts, fmt.Sprintf("Due in %dd", days))
-			}
-		}
-	}
-
-	if i.issue.SLABreachesAt != nil {
-		if t, err := time.Parse(time.RFC3339, *i.issue.SLABreachesAt); err == nil {
-			d := time.Until(t)
-			var slaStr string
-			switch {
-			case d < 0:
-				slaStr = lipgloss.NewStyle().Foreground(redColor).Render("SLA BREACHED")
-			case d <= 24*time.Hour:
-				slaStr = lipgloss.NewStyle().Foreground(redColor).Render(fmt.Sprintf("SLA %dh", int(d.Hours())))
-			case d <= 3*24*time.Hour:
-				slaStr = lipgloss.NewStyle().Foreground(orangeColor).Render(fmt.Sprintf("SLA %dd", int(d.Hours()/24)))
-			default:
-				slaStr = commentDimStyle.Render(fmt.Sprintf("SLA %dd", int(d.Hours()/24)))
-			}
-			parts = append(parts, slaStr)
-		}
-	}
-
-	if n := len(i.issue.Children.Nodes); n > 0 {
-		done := 0
-		for _, c := range i.issue.Children.Nodes {
-			if c.State.Type == "completed" {
-				done++
-			}
-		}
-		parts = append(parts, fmt.Sprintf("[%d/%d]", done, n))
-	}
-
-	if labels := i.issue.Labels.Nodes; len(labels) > 0 {
-		maxLabels := 2
-		if len(labels) < maxLabels {
-			maxLabels = len(labels)
-		}
-		for _, l := range labels[:maxLabels] {
-			style := lipgloss.NewStyle().Foreground(lipgloss.Color(l.Color))
-			parts = append(parts, style.Render(l.Name))
-		}
-		if remaining := len(labels) - maxLabels; remaining > 0 {
-			parts = append(parts, commentDimStyle.Render(fmt.Sprintf("+%d", remaining)))
-		}
-	}
-
-	return strings.Join(parts, " | ")
-}
-
-func (i issueItem) FilterValue() string {
-	return i.issue.Identifier + " " + i.issue.Title
-}
-
-type launchOption struct {
-	action    string
-	title     string
-	desc      string
-	slotIndex int
-}
-
-func (l launchOption) Title() string       { return l.title }
-func (l launchOption) Description() string { return l.desc }
-func (l launchOption) FilterValue() string { return l.title }
-
-type linkItem struct {
-	label   string
-	value   string
-	isIssue bool
-}
-
-func (l linkItem) Title() string       { return l.label }
-func (l linkItem) Description() string { return "" }
-func (l linkItem) FilterValue() string { return l.label }
-
-func statusIcon(stateType string) string {
-	switch stateType {
-	case "backlog":
-		return lipgloss.NewStyle().Foreground(subtleColor).Render("○")
-	case "unstarted":
-		return lipgloss.NewStyle().Foreground(dimColor).Render("○")
-	case "started":
-		return lipgloss.NewStyle().Foreground(yellowColor).Render("●")
-	case "completed":
-		return lipgloss.NewStyle().Foreground(greenColor).Render("✓")
-	case "cancelled":
-		return lipgloss.NewStyle().Foreground(mutedColor).Render("✗")
-	default:
-		return "?"
-	}
-}
-
-func priorityIcon(p int) string {
-	switch p {
-	case 1:
-		return urgentStyle.Render("▲")
-	case 2:
-		return highStyle.Render("▲")
-	case 3:
-		return mediumStyle.Render("■")
-	case 4:
-		return lowStyle.Render("▼")
-	default:
-		return " "
-	}
-}
-
-type issuesLoadedMsg struct {
-	issues []Issue
-	err    error
-}
-
-type worktreesLoadedMsg struct {
-	branches map[string]bool
-}
-
-type worktreeCreatedMsg struct {
-	path       string
-	identifier string
-	err        error
-	hookErr    error
-}
-
-type claudeLaunchedMsg struct {
-	identifier string
-	err        error
-}
-
-type cmuxSlotOpenedMsg struct {
-	slotIdx    int
-	identifier string
-	wtPath     string
-	err        error
-}
-
-type teamsLoadedMsg struct {
-	err error
-}
-
-type setupCompleteMsg struct {
-	cfg Config
-}
-
-type commentPostedMsg struct {
-	identifier string
-	err        error
-}
-
-type commentsLoadedMsg struct {
-	issueID  string
-	comments []Comment
-	err      error
-}
-
-type launchReadyMsg struct {
-	issue  Issue
-	wtPath string
-	prompt string
-}
-
-type statusPollMsg struct{}
-
-type viewerLoadedMsg struct {
-	viewer *Viewer
-	err    error
-}
-
-type projectsLoadedMsg struct {
-	projects []Project
-	err      error
-}
-
-type statesLoadedMsg struct {
-	states []WorkflowState
-	err    error
-}
-
-type issueAssignedMsg struct {
-	identifier string
-	err        error
-}
-
-type issueUnassignedMsg struct {
-	identifier string
-	err        error
-}
-
-type issueStateChangedMsg struct {
-	identifier string
-	err        error
-}
-
-type branchIssueFoundMsg struct {
-	issue *Issue
-}
-
-type issueNavigatedMsg struct {
-	issue *Issue
-	err   error
-}
-
-type detailContentMsg struct {
-	issueID string
-	content string
-}
-
-type searchResultsMsg struct {
-	issues []Issue
-	err    error
-}
-
-type prefetchTickMsg struct {
-	seq int
-}
-
-type teamSwitchedMsg struct {
-	cfg Config
-	err error
-}
 
 type viewMode int
 
@@ -384,6 +31,7 @@ const (
 	viewLinkList
 	viewSortPicker
 	viewLabelPicker
+	viewWorktreeList
 )
 
 type settingsDraft struct {
@@ -485,6 +133,8 @@ type Model struct {
 	linkList         list.Model
 	linkReturnToView viewMode
 
+	worktreeList list.Model
+
 	detailHistory       []*Issue
 	pendingHistoryIssue *Issue
 
@@ -501,11 +151,11 @@ type confirmAction int
 
 const (
 	confirmQuit confirmAction = iota
-	confirmCloseSlot
 	confirmPostComment
 	confirmAssign
 	confirmUnassign
 	confirmStateChange
+	confirmRemoveWorktree
 )
 
 type confirmDialog struct {
@@ -516,10 +166,11 @@ type confirmDialog struct {
 }
 
 type keyMap struct {
-	Navigate   key.Binding
-	Claude     key.Binding
-	Worktree   key.Binding
-	Close      key.Binding
+	Navigate        key.Binding
+	Claude          key.Binding
+	Worktree     key.Binding
+	Remove       key.Binding
+	WorktreeList key.Binding
 	Comment    key.Binding
 	Detail     key.Binding
 	Filter     key.Binding
@@ -542,8 +193,9 @@ func defaultKeyMap(multiTeam bool) keyMap {
 	km := keyMap{
 		Navigate:   key.NewBinding(key.WithKeys("j", "k"), key.WithHelp("j/k", "navigate")),
 		Claude:     key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "claude+worktree")),
-		Worktree:   key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "worktree")),
-		Close:      key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "close slot")),
+		Worktree:     key.NewBinding(key.WithKeys("W"), key.WithHelp("W", "create worktree")),
+		Remove:       key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "remove worktree")),
+		WorktreeList: key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "worktrees")),
 		Comment:    key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "comment")),
 		Detail:     key.NewBinding(key.WithKeys("d", "enter"), key.WithHelp("enter/d", "detail")),
 		Filter:     key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "cycle filter")),
@@ -573,11 +225,19 @@ func (k keyMap) ShortHelp() []key.Binding {
 
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.Navigate, k.Claude, k.Worktree, k.Close},
+		{k.Navigate, k.Claude, k.Worktree, k.Remove, k.WorktreeList},
 		{k.Detail, k.Filter, k.FilterPick, k.Search},
 		{k.Project, k.Label, k.Assign, k.Unassign, k.Links, k.TeamSwitch},
 		{k.Open, k.Refresh, k.Setup, k.Help, k.Quit},
 	}
+}
+
+func (m *Model) getBranchName(identifier string) string {
+	return m.cfg.BranchPrefix + strings.ToLower(identifier)
+}
+
+func (m *Model) hasWorktree(identifier string) bool {
+	return m.worktreeBranches[m.getBranchName(identifier)]
 }
 
 func (m *Model) selectedIssue() *Issue {
@@ -592,26 +252,18 @@ func (m *Model) selectedIssue() *Issue {
 }
 
 func (m *Model) rebuildList() {
-	slotMap := make(map[string]*WorktreeSlot)
-	if m.paneManager != nil {
-		for _, slot := range m.paneManager.Slots() {
-			if slot != nil {
-				slotMap[slot.Issue.Identifier] = slot
-			}
-		}
-	}
-
 	items := make([]list.Item, len(m.issues))
 	for i, issue := range m.issues {
-		branch := m.cfg.BranchPrefix + strings.ToLower(issue.Identifier)
 		item := issueItem{
 			issue:       issue,
-			hasWorktree: m.worktreeBranches[branch],
+			hasWorktree: m.hasWorktree(issue.Identifier),
 			slotIdx:     -1,
 		}
-		if slot, ok := slotMap[issue.Identifier]; ok {
-			item.slotIdx = slot.Index
-			item.slotStatus = slot.Status
+		if m.paneManager != nil {
+			if slot, _ := m.paneManager.FindSlotByIdentifier(issue.Identifier); slot != nil {
+				item.slotIdx = slot.Index
+				item.slotStatus = slot.Status
+			}
 		}
 		items[i] = item
 	}

--- a/model_test.go
+++ b/model_test.go
@@ -88,6 +88,225 @@ func TestCmuxFallbackUsesMessageWorktreePath(t *testing.T) {
 	}
 }
 
+func TestLaunchReadyMsgHookErrorSetsWarning(t *testing.T) {
+	m := NewModel(Config{
+		ClaudeCommand: "claude",
+		WorktreeBase:  "/tmp/wt",
+	})
+
+	result, cmd := m.Update(launchReadyMsg{
+		issue:   Issue{Identifier: "TEST-1", Title: "Test"},
+		wtPath:  "/tmp/wt/test-1",
+		prompt:  "hello",
+		hookErr: errors.New("npm install failed"),
+	})
+
+	model := result.(Model)
+	if !strings.Contains(model.statusMsg, "hook failed") {
+		t.Errorf("expected statusMsg to contain 'hook failed', got %q", model.statusMsg)
+	}
+	if cmd == nil {
+		t.Error("expected launch cmd to still proceed despite hook error")
+	}
+}
+
+func TestLaunchReadyMsgNoHookError(t *testing.T) {
+	m := NewModel(Config{
+		ClaudeCommand: "claude",
+		WorktreeBase:  "/tmp/wt",
+	})
+
+	result, cmd := m.Update(launchReadyMsg{
+		issue:  Issue{Identifier: "TEST-1", Title: "Test"},
+		wtPath: "/tmp/wt/test-1",
+		prompt: "hello",
+	})
+
+	model := result.(Model)
+	if model.statusMsg != "" {
+		t.Errorf("expected empty statusMsg when no hook error, got %q", model.statusMsg)
+	}
+	if cmd == nil {
+		t.Error("expected launch cmd")
+	}
+}
+
+func TestRemoveWorktreeConfirmDialog(t *testing.T) {
+	m := NewModel(Config{
+		LinearAPIKey:  "lin_api_test",
+		TeamID:        "team-1",
+		TeamKey:       "TEST",
+		ClaudeCommand: "claude",
+		WorktreeBase:  "/tmp/wt",
+		BranchPrefix:  "feature/",
+	})
+	m.issues = []Issue{{Identifier: "TEST-1", Title: "Test"}}
+	m.worktreeBranches = map[string]bool{"feature/test-1": true}
+	m.rebuildList()
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	model := result.(*Model)
+
+	if model.confirm == nil {
+		t.Fatal("expected confirmation dialog")
+	}
+	if model.confirm.action != confirmRemoveWorktree {
+		t.Errorf("expected confirmRemoveWorktree, got %d", model.confirm.action)
+	}
+	if !strings.Contains(model.confirm.message, "TEST-1") {
+		t.Errorf("expected message to mention TEST-1, got %q", model.confirm.message)
+	}
+}
+
+func TestRemoveWorktreeNoWorktree(t *testing.T) {
+	m := NewModel(Config{
+		LinearAPIKey:  "lin_api_test",
+		TeamID:        "team-1",
+		TeamKey:       "TEST",
+		ClaudeCommand: "claude",
+		WorktreeBase:  "/tmp/wt",
+		BranchPrefix:  "feature/",
+	})
+	m.issues = []Issue{{Identifier: "TEST-1", Title: "Test"}}
+	m.worktreeBranches = map[string]bool{}
+	m.rebuildList()
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	model := result.(*Model)
+
+	if model.confirm != nil {
+		t.Error("expected no confirmation dialog when issue has no worktree")
+	}
+	if !strings.Contains(model.statusMsg, "no worktree") {
+		t.Errorf("expected 'no worktree' status, got %q", model.statusMsg)
+	}
+}
+
+func TestWorktreeRemovedMsgSuccess(t *testing.T) {
+	m := NewModel(Config{
+		ClaudeCommand: "claude",
+		WorktreeBase:  "/tmp/wt",
+		BranchPrefix:  "feature/",
+	})
+
+	result, cmd := m.Update(worktreeRemovedMsg{identifier: "TEST-1"})
+	model := result.(Model)
+
+	if !strings.Contains(model.statusMsg, "Removed worktree") {
+		t.Errorf("expected success status, got %q", model.statusMsg)
+	}
+	if cmd == nil {
+		t.Error("expected fetchWorktrees cmd")
+	}
+}
+
+func TestWorktreeRemovedMsgError(t *testing.T) {
+	m := NewModel(Config{
+		ClaudeCommand: "claude",
+		WorktreeBase:  "/tmp/wt",
+		BranchPrefix:  "feature/",
+	})
+
+	result, _ := m.Update(worktreeRemovedMsg{
+		identifier: "TEST-1",
+		err:        errors.New("permission denied"),
+	})
+	model := result.(Model)
+
+	if !strings.Contains(model.statusMsg, "Error removing") {
+		t.Errorf("expected error status, got %q", model.statusMsg)
+	}
+}
+
+func TestBuildWorktreeListItems(t *testing.T) {
+	m := NewModel(Config{
+		LinearAPIKey:  "lin_api_test",
+		TeamID:        "team-1",
+		TeamKey:       "TEST",
+		ClaudeCommand: "claude",
+		WorktreeBase:  "/tmp/wt",
+		BranchPrefix:  "feature/",
+	})
+
+	worktrees := []Worktree{
+		{Path: "/repo", Branch: "main", Head: "abc123", Bare: true},
+		{Path: "/tmp/wt/test-1", Branch: "feature/test-1", Head: "def456"},
+		{Path: "/tmp/wt/test-2", Branch: "feature/test-2", Head: "ghi789"},
+		{Path: "/tmp/wt/manual", Branch: "manual-branch", Head: "jkl012"},
+	}
+
+	items := m.buildWorktreeListItems(worktrees)
+
+	// 2 managed + 1 separator + 1 other = 4
+	if len(items) != 4 {
+		t.Fatalf("expected 4 items (bare skipped, separator added), got %d", len(items))
+	}
+
+	wi0 := items[0].(worktreeItem)
+	if wi0.identifier != "TEST-1" {
+		t.Errorf("item[0].identifier = %q, want TEST-1", wi0.identifier)
+	}
+	if wi0.slotIdx != -1 {
+		t.Errorf("item[0].slotIdx = %d, want -1 (no slot)", wi0.slotIdx)
+	}
+
+	// item[2] should be the separator
+	if _, ok := items[2].(worktreeSeparator); !ok {
+		t.Errorf("item[2] should be worktreeSeparator, got %T", items[2])
+	}
+
+	wi3 := items[3].(worktreeItem)
+	if wi3.identifier != "" {
+		t.Errorf("item[3].identifier = %q, want empty (no matching prefix)", wi3.identifier)
+	}
+}
+
+func TestWorktreeListEscReturnsToList(t *testing.T) {
+	m := NewModel(Config{
+		LinearAPIKey:  "lin_api_test",
+		TeamID:        "team-1",
+		TeamKey:       "TEST",
+		ClaudeCommand: "claude",
+		WorktreeBase:  "/tmp/wt",
+		BranchPrefix:  "feature/",
+	})
+	m.view = viewWorktreeList
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model := result.(*Model)
+
+	if model.view != viewList {
+		t.Errorf("expected viewList after esc, got %d", model.view)
+	}
+}
+
+func TestWorktreeListLoadedMsg(t *testing.T) {
+	m := NewModel(Config{
+		LinearAPIKey:  "lin_api_test",
+		TeamID:        "team-1",
+		TeamKey:       "TEST",
+		ClaudeCommand: "claude",
+		WorktreeBase:  "/tmp/wt",
+		BranchPrefix:  "feature/",
+	})
+	m.width = 80
+	m.height = 24
+
+	result, _ := m.Update(worktreeListLoadedMsg{
+		worktrees: []Worktree{
+			{Path: "/tmp/wt/test-1", Branch: "feature/test-1", Head: "abc123"},
+		},
+	})
+	model := result.(Model)
+
+	if model.view != viewWorktreeList {
+		t.Errorf("expected viewWorktreeList, got %d", model.view)
+	}
+	if !strings.Contains(model.statusMsg, "1 worktrees") {
+		t.Errorf("expected '1 worktrees' status, got %q", model.statusMsg)
+	}
+}
+
 func TestSettingsInitOnFirstRun(t *testing.T) {
 	cfg := DefaultConfig() // NeedsSetup() == true
 	m := NewModel(cfg)

--- a/model_theme.go
+++ b/model_theme.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/compat"
+)
+
+var (
+	// Adaptive colors for light/dark terminal themes.
+	// AdaptiveColor: {Light, Dark}
+	// Adaptive colors for WCAG AA contrast on both light and dark backgrounds.
+	// Light values target >= 4.5:1 against #F5F5F5; dark values target visibility on #1E1E1E.
+	dimColor       = compat.AdaptiveColor{Light: lipgloss.Color("#444"), Dark: lipgloss.Color("#888")}
+	subtleColor    = compat.AdaptiveColor{Light: lipgloss.Color("#555"), Dark: lipgloss.Color("#555")}
+	mutedColor     = compat.AdaptiveColor{Light: lipgloss.Color("#555"), Dark: lipgloss.Color("#666")}
+	faintColor     = compat.AdaptiveColor{Light: lipgloss.Color("#646464"), Dark: lipgloss.Color("#444")}
+	yellowColor    = compat.AdaptiveColor{Light: lipgloss.Color("#B45309"), Dark: lipgloss.Color("#EAB308")}
+	identCyanColor = compat.AdaptiveColor{Light: lipgloss.Color("#0E7490"), Dark: lipgloss.Color("#06B6D4")}
+	greenColor     = compat.AdaptiveColor{Light: lipgloss.Color("#15803D"), Dark: lipgloss.Color("#22C55E")}
+	redColor       = compat.AdaptiveColor{Light: lipgloss.Color("#B91C1C"), Dark: lipgloss.Color("#EF4444")}
+	orangeColor    = compat.AdaptiveColor{Light: lipgloss.Color("#C2410C"), Dark: lipgloss.Color("#F97316")}
+	blueColor      = compat.AdaptiveColor{Light: lipgloss.Color("#2563EB"), Dark: lipgloss.Color("#3B82F6")}
+
+	appStyle = lipgloss.NewStyle().Padding(0, 1)
+
+	titleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#7C3AED")).
+			Padding(0, 1)
+
+	statusBarStyle = lipgloss.NewStyle().
+			Foreground(dimColor).
+			Padding(0, 1)
+
+	issueIdentStyle = lipgloss.NewStyle().
+			Foreground(identCyanColor).
+			Bold(true)
+
+	worktreeMarker = lipgloss.NewStyle().
+			Foreground(greenColor)
+
+	urgentStyle = lipgloss.NewStyle().Foreground(redColor)
+	highStyle   = lipgloss.NewStyle().Foreground(orangeColor)
+	mediumStyle = lipgloss.NewStyle().Foreground(yellowColor)
+	lowStyle    = lipgloss.NewStyle().Foreground(blueColor)
+
+	setupStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#7C3AED")).
+			Padding(1, 2).
+			Width(50)
+
+	slotRunningStyle = lipgloss.NewStyle().Foreground(greenColor)
+	slotWaitingStyle = lipgloss.NewStyle().Foreground(yellowColor)
+	slotIdleStyle    = lipgloss.NewStyle().Foreground(dimColor)
+	slotEmptyStyle   = lipgloss.NewStyle().Foreground(faintColor)
+
+	commentDimStyle = lipgloss.NewStyle().Foreground(dimColor)
+
+	activeTabStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#7C3AED")).
+			Border(lipgloss.NormalBorder(), false, false, true, false).
+			BorderForeground(lipgloss.Color("#7C3AED")).
+			Padding(0, 2)
+
+	inactiveTabStyle = lipgloss.NewStyle().
+				Foreground(dimColor).
+				Border(lipgloss.NormalBorder(), false, false, true, false).
+				BorderForeground(faintColor).
+				Padding(0, 2)
+)

--- a/model_update.go
+++ b/model_update.go
@@ -26,6 +26,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.list.SetSize(msg.Width-2, listHeight)
 		m.linkList.SetSize(msg.Width-4, msg.Height-4)
+		m.worktreeList.SetSize(msg.Width-4, msg.Height-4)
 		if m.settingsTabs[0] != nil {
 			w := msg.Width - 4
 			if w < 60 {
@@ -106,6 +107,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateSearch(msg)
 		case viewLinkList:
 			return m.updateLinkList(msg)
+		case viewWorktreeList:
+			return m.updateWorktreeList(msg)
 		default:
 			return m.updateList(msg)
 		}
@@ -205,10 +208,39 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case launchReadyMsg:
+		if msg.hookErr != nil {
+			m.statusMsg = fmt.Sprintf("Warning: post-create hook failed: %v", msg.hookErr)
+		}
 		if m.useCmux && m.paneManager != nil {
 			return m, m.openCmuxSlotWithPromptCmd(msg.issue, msg.wtPath, msg.prompt)
 		}
 		return m, m.launchClaudeWithPromptCmd(msg.wtPath, msg.issue, msg.prompt)
+
+	case worktreeRemovedMsg:
+		if msg.err != nil {
+			m.statusMsg = fmt.Sprintf("Error removing worktree: %v", msg.err)
+			return m, nil
+		}
+		m.statusMsg = fmt.Sprintf("Removed worktree for %s", msg.identifier)
+		m.rebuildList()
+		cmds := []tea.Cmd{m.fetchWorktrees()}
+		if m.view == viewWorktreeList {
+			cmds = append(cmds, m.fetchWorktreeListCmd())
+		}
+		return m, tea.Batch(cmds...)
+
+	case worktreeListLoadedMsg:
+		if msg.err != nil {
+			m.statusMsg = fmt.Sprintf("Error loading worktrees: %v", msg.err)
+			return m, nil
+		}
+		items := m.buildWorktreeListItems(msg.worktrees)
+		m.worktreeList.SetItems(items)
+		m.worktreeList.SetSize(m.width-4, m.height-4)
+		m.worktreeList.Select(0)
+		m.view = viewWorktreeList
+		m.statusMsg = fmt.Sprintf("%d worktrees", len(items))
+		return m, nil
 
 	case statusPollMsg:
 		if m.paneManager != nil {
@@ -454,7 +486,7 @@ func (m *Model) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, key.NewBinding(key.WithKeys("c"))):
 		return m.beginLaunchFromSelection()
 
-	case key.Matches(msg, key.NewBinding(key.WithKeys("w"))):
+	case key.Matches(msg, key.NewBinding(key.WithKeys("W"))):
 		return m.createSelectedWorktree()
 
 	case key.Matches(msg, key.NewBinding(key.WithKeys("x"))):
@@ -462,13 +494,20 @@ func (m *Model) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if issue == nil {
 			return m, nil
 		}
+		if !m.hasWorktree(issue.Identifier) {
+			m.statusMsg = fmt.Sprintf("%s has no worktree", issue.Identifier)
+			return m, nil
+		}
 		m.confirm = &confirmDialog{
-			action:  confirmCloseSlot,
-			title:   "Close Slot?",
-			message: fmt.Sprintf("Close the Claude session for %s?", issue.Identifier),
-			onYes:   func(m *Model) (tea.Model, tea.Cmd) { return m.closeSelectedSlot() },
+			action:  confirmRemoveWorktree,
+			title:   "Remove Worktree?",
+			message: fmt.Sprintf("Remove worktree and branch for %s? This cannot be undone.", issue.Identifier),
+			onYes:   func(m *Model) (tea.Model, tea.Cmd) { return m.removeSelectedWorktree() },
 		}
 		return m, nil
+
+	case key.Matches(msg, key.NewBinding(key.WithKeys("w"))):
+		return m, m.fetchWorktreeListCmd()
 
 	case key.Matches(msg, key.NewBinding(key.WithKeys("d", "enter"))):
 		return m.showSelectedIssueDetail()

--- a/model_update.go
+++ b/model_update.go
@@ -239,7 +239,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.worktreeList.SetSize(m.width-4, m.height-4)
 		m.worktreeList.Select(0)
 		m.view = viewWorktreeList
-		m.statusMsg = fmt.Sprintf("%d worktrees", len(items))
+		wtCount := 0
+		for _, item := range items {
+			if _, ok := item.(worktreeItem); ok {
+				wtCount++
+			}
+		}
+		m.statusMsg = fmt.Sprintf("%d worktrees", wtCount)
 		return m, nil
 
 	case statusPollMsg:

--- a/model_view.go
+++ b/model_view.go
@@ -30,6 +30,8 @@ func (m Model) View() tea.View {
 		base = m.viewPicker("Transition State", m.stateForm)
 	case viewLinkList:
 		base = m.viewLinkList()
+	case viewWorktreeList:
+		base = m.viewWorktreeList()
 	case viewFilterPicker:
 		base = m.viewPicker("Filter Issues", m.filterForm)
 	case viewSortPicker:
@@ -120,10 +122,10 @@ func (m Model) viewList() string {
 	legend := statusBarStyle.Render(renderLegendCompact())
 	var row1, row2 string
 	if len(m.cfg.Teams) > 1 {
-		row1 = "enter:detail  c:claude  1-9:team  p:project  L:labels"
+		row1 = "enter:detail  c:claude  1-9:team  p:project  L:labels  w:worktrees"
 		row2 = "f:filter  o:sort  s:settings  ?:help"
 	} else {
-		row1 = "enter:detail  c:claude  p:project  L:labels"
+		row1 = "enter:detail  c:claude  p:project  L:labels  w:worktrees"
 		row2 = "f:filter  o:sort  s:settings(+teams)  ?:help"
 	}
 	shortcutText := row1 + "  " + row2
@@ -231,6 +233,11 @@ func (m Model) renderSlotBar() string {
 		)
 	}
 	return lipgloss.NewStyle().Padding(0, 1).Render(strings.Join(parts, "  "))
+}
+
+func (m Model) viewWorktreeList() string {
+	status := statusBarStyle.Render("[Enter] detail  [x] remove worktree  [Esc] back")
+	return appStyle.Render(lipgloss.JoinVertical(lipgloss.Left, m.worktreeList.View(), status))
 }
 
 func (m Model) viewLinkList() string {

--- a/testdata/golden/list_demo_issues.txt
+++ b/testdata/golden/list_demo_issues.txt
@@ -1,39 +1,40 @@
-                                                                                             
-                                                                                             
-    ENG > [Assigned to me]                                                                   
-                                                                                             
- │ ● ▲ ENG-142 Add rate limiting to public API endpoints                                     
- │ Alex | Platform Hardening | backend | security                                            
-   ● ▲ ENG-138 Fix connection pool exhaustion under load                                     
-   Alex | Platform Hardening | bug | backend                                                 
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-                                                                                             
-  ENG | 2 issues | Assigned to me | Updated                                                  
-  ○ Backlog ○ Todo ● In Progress ✓ Done  ▲ Urgent ▲ High ■ Med ▼ Low                         
-  enter:detail  c:claude  p:project  L:labels  f:filter  o:sort  s:settings(+teams)  ?:help  
+                                                                      
+                                                                      
+    ENG > [Assigned to me]                                            
+                                                                      
+ │ ● ▲ ENG-142 Add rate limiting to public API endpoints              
+ │ Alex | Platform Hardening | backend | security                     
+   ● ▲ ENG-138 Fix connection pool exhaustion under load              
+   Alex | Platform Hardening | bug | backend                          
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+                                                                      
+  ENG | 2 issues | Assigned to me | Updated                           
+  ○ Backlog ○ Todo ● In Progress ✓ Done  ▲ Urgent ▲ High ■ Med ▼ Low  
+  enter:detail  c:claude  p:project  L:labels  w:worktrees            
+  f:filter  o:sort  s:settings(+teams)  ?:help                        

--- a/testdata/golden/list_empty_assigned.txt
+++ b/testdata/golden/list_empty_assigned.txt
@@ -36,4 +36,5 @@
                                                                                                     
   TST | 0 issues | Assigned to me | Updated                                                         
   ○ Backlog ○ Todo ● In Progress ✓ Done  ▲ Urgent ▲ High ■ Med ▼ Low                                
-  enter:detail  c:claude  p:project  L:labels  f:filter  o:sort  s:settings(+teams)  ?:help         
+  enter:detail  c:claude  p:project  L:labels  w:worktrees                                          
+  f:filter  o:sort  s:settings(+teams)  ?:help                                                      


### PR DESCRIPTION
## Summary

- **Worktree management list** (`w` key): dedicated view showing all worktrees, grouped by managed (matching branch prefix) vs other worktrees. Supports `Enter` to navigate to issue detail, `x` to remove.
- **Worktree cleanup** (`x` key): removes worktree and branch from disk with confirmation dialog. Automatically closes any active cmux slot first.
- **Hook error propagation**: post-create hook failures now show a warning in the status bar instead of being silently dropped. Launch still proceeds.
- **Detail view**: shows worktree status (active + slot info) in issue metadata when a worktree exists.
- **Refactoring**: split `model_state.go` (725 -> 372 lines) into `model_theme.go`, `model_items.go`, `model_messages.go`. Added `PaneManager.FindSlotByIdentifier()` replacing 5 inline loops. De-duplicated prompt building in `cmux.go`. Removed dead code.

Closes #38, closes #39, closes #40

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass (9 new tests added)
- [x] Manual: `w` opens worktree list with grouped display
- [x] Manual: `x` on issue with worktree shows confirmation, removes on confirm
- [x] Manual: `x` on issue without worktree shows "no worktree" message
- [x] Manual: worktree status visible in issue detail view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Worktree list view for browsing/managing worktrees (toggle with `w`), including navigation and detail entry
  - Remove worktrees with confirmation (`x`) and improved create/remove flows
  - Worktree status indicators and slot metadata shown in issue detail and lists
  - Window resizing now adjusts the worktree list

* **Bug Fixes / UX**
  - Launch now surfaces post-create hook failures in status messages

* **Tests**
  - Added tests for worktree flows, removal confirmation, hook error handling, and list navigation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->