### PR TITLE
feat: worktree workflow improvements (medium priority)

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -577,16 +577,21 @@ func (pm *PaneManager) logEvent(level, message string) {
 }
 
 // inferStatus pattern-matches terminal content to determine Claude's state.
+// Lines are scanned newest-to-oldest so that recent prompts override stale
+// patterns (e.g. an old [y/n] above a fresh idle prompt).
 func inferStatus(terminalText string) AgentStatus {
-	// Look for Claude Code's UI patterns
-	if containsAny(terminalText, "[y/n]", "[Y/n]") {
-		return AgentWaiting
-	}
-	if containsAny(terminalText, "to interrupt", "ctrl+c") {
-		return AgentRunning
-	}
-	if containsAny(terminalText, "❯", "\n> ") || strings.TrimSpace(terminalText) == ">" {
-		return AgentIdle
+	lines := strings.Split(terminalText, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := lines[i]
+		if containsAny(line, "[y/n]", "[Y/n]") {
+			return AgentWaiting
+		}
+		if containsAny(line, "to interrupt", "ctrl+c") {
+			return AgentRunning
+		}
+		if containsAny(line, "❯", "> ") || strings.TrimSpace(line) == ">" {
+			return AgentIdle
+		}
 	}
 	return AgentRunning // default to running if we can't tell
 }

--- a/cmux.go
+++ b/cmux.go
@@ -17,6 +17,7 @@ const (
 	defaultSocketPath  = "/tmp/cmux.sock"
 	defaultMaxSlots    = 3
 	absoluteMaxSlots   = 4
+	statusReadLines    = 20 // lines read from the bottom of each pane for inferStatus; must catch Claude Code prompts that may scroll above the last few lines
 )
 
 // CmuxClient manages communication with cmux via its Unix socket API.
@@ -476,7 +477,7 @@ func (pm *PaneManager) PollStatus() {
 		if slot == nil {
 			continue
 		}
-		text, err := pm.client.ReadText(pm.workspaceID, slot.SurfaceID, 5)
+		text, err := pm.client.ReadText(pm.workspaceID, slot.SurfaceID, statusReadLines)
 		if err != nil {
 			continue
 		}

--- a/cmux.go
+++ b/cmux.go
@@ -583,13 +583,14 @@ func inferStatus(terminalText string) AgentStatus {
 	lines := strings.Split(terminalText, "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
 		line := lines[i]
+		trimmed := strings.TrimSpace(line)
 		if containsAny(line, "[y/n]", "[Y/n]") {
 			return AgentWaiting
 		}
 		if containsAny(line, "to interrupt", "ctrl+c") {
 			return AgentRunning
 		}
-		if containsAny(line, "❯", "> ") || strings.TrimSpace(line) == ">" {
+		if strings.Contains(line, "❯") || trimmed == ">" || trimmed == "> " {
 			return AgentIdle
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -27,6 +27,32 @@ type Config struct {
 	MaxSlots       int    `json:"max_slots"` // 2, 3, or 4
 	PostCreateHook string `json:"post_create_hook"`
 	PromptTemplate string `json:"prompt_template"`
+	SlotColors     []string `json:"slot_colors,omitempty"` // palette name per slot (indexed 0..3); see slotPaletteNames
+}
+
+// slotPaletteNames lists the palette entries accepted in Config.SlotColors.
+// Values map to adaptive colors via slotPaletteColor in model_theme.go.
+var slotPaletteNames = []string{"green", "blue", "purple", "orange", "pink", "cyan", "yellow", "red"}
+
+// defaultSlotColors returns the default per-slot palette assignment.
+var defaultSlotColors = []string{"green", "blue", "purple", "orange"}
+
+// SlotColorName returns the palette name configured for the given slot index,
+// falling back to the default assignment. The returned name is always a valid
+// palette entry.
+func (c Config) SlotColorName(idx int) string {
+	if idx >= 0 && idx < len(c.SlotColors) {
+		name := c.SlotColors[idx]
+		for _, valid := range slotPaletteNames {
+			if name == valid {
+				return name
+			}
+		}
+	}
+	if idx >= 0 && idx < len(defaultSlotColors) {
+		return defaultSlotColors[idx]
+	}
+	return "green"
 }
 
 func DefaultConfig() Config {

--- a/config_test.go
+++ b/config_test.go
@@ -30,6 +30,37 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestSlotColorName(t *testing.T) {
+	cfg := Config{}
+	// Defaults when unconfigured
+	want := []string{"green", "blue", "purple", "orange"}
+	for i, w := range want {
+		if got := cfg.SlotColorName(i); got != w {
+			t.Errorf("default SlotColorName(%d) = %q, want %q", i, got, w)
+		}
+	}
+
+	// Configured values
+	cfg.SlotColors = []string{"pink", "cyan", "yellow", "red"}
+	for i, w := range cfg.SlotColors {
+		if got := cfg.SlotColorName(i); got != w {
+			t.Errorf("SlotColorName(%d) = %q, want %q", i, got, w)
+		}
+	}
+
+	// Invalid palette name falls back to default
+	cfg.SlotColors = []string{"nonsense"}
+	if got := cfg.SlotColorName(0); got != "green" {
+		t.Errorf("invalid slot color should fall back to default 'green', got %q", got)
+	}
+
+	// Out-of-range index uses default assignment
+	cfg.SlotColors = []string{"pink"}
+	if got := cfg.SlotColorName(2); got != "purple" {
+		t.Errorf("SlotColorName(2) with single-entry config = %q, want 'purple'", got)
+	}
+}
+
 func TestConfigNeedsSetup(t *testing.T) {
 	cfg := DefaultConfig()
 	if !cfg.NeedsSetup() {

--- a/model.go
+++ b/model.go
@@ -96,6 +96,7 @@ func NewModel(cfg Config) Model {
 		cfg:              cfg,
 		list:             l,
 		worktreeBranches: make(map[string]bool),
+		worktreePaths:    make(map[string]string),
 		filter:           FilterAssigned,
 		view:             viewList,
 		commentInput:     commentIn,

--- a/model_commands.go
+++ b/model_commands.go
@@ -40,12 +40,14 @@ func (m Model) fetchWorktrees() tea.Cmd {
 	return func() tea.Msg {
 		wts, err := ListWorktrees()
 		branches := make(map[string]bool)
+		paths := make(map[string]string)
 		if err == nil {
 			for _, wt := range wts {
 				branches[wt.Branch] = true
+				paths[wt.Branch] = wt.Path
 			}
 		}
-		return worktreesLoadedMsg{branches: branches}
+		return worktreesLoadedMsg{branches: branches, paths: paths}
 	}
 }
 

--- a/model_detail.go
+++ b/model_detail.go
@@ -180,17 +180,7 @@ func (m Model) writeDetailMetadata(b *strings.Builder, issue *Issue, ctx detailR
 		wtStatus := worktreeMarker.Render("active")
 		if m.paneManager != nil {
 			if slot, _ := m.paneManager.FindSlotByIdentifier(issue.Identifier); slot != nil {
-				var style lipgloss.Style
-				switch slot.Status {
-				case AgentRunning:
-					style = slotRunningStyle
-				case AgentWaiting:
-					style = slotWaitingStyle
-				case AgentIdle:
-					style = slotIdleStyle
-				default:
-					style = slotEmptyStyle
-				}
+				style := slotBadgeStyle(m.cfg.SlotColorName(slot.Index), slot.Status)
 				wtStatus += " " + style.Render(fmt.Sprintf("[slot %d: %s]", slot.Index+1, slot.Status.Label()))
 			}
 		}

--- a/model_items.go
+++ b/model_items.go
@@ -184,7 +184,11 @@ func (w worktreeItem) Description() string {
 	if len(short) > 8 {
 		short = short[:8]
 	}
-	return fmt.Sprintf("%s  %s", short, w.path)
+	prefix := ""
+	if w.slotIdx >= 0 {
+		prefix = fmt.Sprintf("slot %d · ", w.slotIdx+1)
+	}
+	return fmt.Sprintf("%s%s  %s", prefix, short, w.path)
 }
 
 func (w worktreeItem) FilterValue() string {

--- a/model_items.go
+++ b/model_items.go
@@ -13,6 +13,7 @@ type issueItem struct {
 	hasWorktree bool
 	slotIdx     int
 	slotStatus  AgentStatus
+	slotColor   string // palette name; empty until a slot is attached
 }
 
 func (i issueItem) Title() string {
@@ -25,17 +26,7 @@ func (i issueItem) Title() string {
 
 	slot := ""
 	if i.slotIdx >= 0 {
-		var style lipgloss.Style
-		switch i.slotStatus {
-		case AgentRunning:
-			style = slotRunningStyle
-		case AgentWaiting:
-			style = slotWaitingStyle
-		case AgentIdle:
-			style = slotIdleStyle
-		default:
-			style = slotEmptyStyle
-		}
+		style := slotBadgeStyle(i.slotColor, i.slotStatus)
 		slot = style.Render(fmt.Sprintf(" [%d:%s]", i.slotIdx+1, i.slotStatus.String()))
 	}
 
@@ -154,22 +145,13 @@ type worktreeItem struct {
 	identifier string
 	slotIdx    int
 	slotStatus AgentStatus
+	slotColor  string // palette name; empty until a slot is attached
 }
 
 func (w worktreeItem) Title() string {
 	slot := ""
 	if w.slotIdx >= 0 {
-		var style lipgloss.Style
-		switch w.slotStatus {
-		case AgentRunning:
-			style = slotRunningStyle
-		case AgentWaiting:
-			style = slotWaitingStyle
-		case AgentIdle:
-			style = slotIdleStyle
-		default:
-			style = slotEmptyStyle
-		}
+		style := slotBadgeStyle(w.slotColor, w.slotStatus)
 		slot = style.Render(fmt.Sprintf(" [%d:%s]", w.slotIdx+1, w.slotStatus.String()))
 	}
 	ident := ""

--- a/model_list_actions.go
+++ b/model_list_actions.go
@@ -126,6 +126,7 @@ func (m *Model) buildWorktreeListItems(worktrees []Worktree) []list.Item {
 		if slot, ok := slotMap[wt.Path]; ok {
 			item.slotIdx = slot.Index
 			item.slotStatus = slot.Status
+			item.slotColor = m.cfg.SlotColorName(slot.Index)
 		}
 
 		if identifier != "" {

--- a/model_messages.go
+++ b/model_messages.go
@@ -7,6 +7,7 @@ type issuesLoadedMsg struct {
 
 type worktreesLoadedMsg struct {
 	branches map[string]bool
+	paths    map[string]string
 }
 
 type worktreeCreatedMsg struct {

--- a/model_pickers.go
+++ b/model_pickers.go
@@ -413,7 +413,7 @@ func (m *Model) updateWorktreeList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.confirm = &confirmDialog{
 			action:  confirmRemoveWorktree,
 			title:   "Remove Worktree?",
-			message: fmt.Sprintf("Remove worktree and branch %s? This cannot be undone.", wi.branch),
+			message: BuildRemoveWorktreeMessage(wi.path, wi.branch),
 			onYes: func(m *Model) (tea.Model, tea.Cmd) {
 				if wi.slotIdx >= 0 && m.paneManager != nil {
 					_ = m.paneManager.CloseSlot(wi.slotIdx)

--- a/model_settings.go
+++ b/model_settings.go
@@ -26,6 +26,9 @@ func (m *Model) initSettingsForm() {
 		hook:       m.cfg.PostCreateHook,
 		prompt:     m.cfg.PromptTemplate,
 	}
+	for i := 0; i < absoluteMaxSlots; i++ {
+		draft.slotColors[i] = m.cfg.SlotColorName(i)
+	}
 	if len(m.cfg.Teams) > 0 {
 		keys := make([]string, len(m.cfg.Teams))
 		for i, t := range m.cfg.Teams {
@@ -44,7 +47,7 @@ func (m *Model) initSettingsForm() {
 		w = 60
 	}
 
-	m.settingsTabNames = [3]string{"Credentials", "Worktree", "Launch"}
+	m.settingsTabNames = [4]string{"Credentials", "Worktree", "Launch", "Slots"}
 	for i := range m.settingsTabs {
 		m.settingsTabs[i] = m.buildTab(i, w)
 	}
@@ -95,7 +98,7 @@ func (m *Model) buildTab(index, w int) *huh.Form {
 					Value(&m.settingsDraft.branch),
 			),
 		).WithWidth(w).WithShowHelp(false).WithShowErrors(true)
-	default:
+	case 2:
 		return huh.NewForm(
 			huh.NewGroup(
 				huh.NewInput().
@@ -133,6 +136,23 @@ func (m *Model) buildTab(index, w int) *huh.Form {
 					).
 					Value(&m.settingsDraft.maxSlots),
 			),
+		).WithWidth(w).WithShowHelp(false).WithShowErrors(true)
+	default:
+		opts := make([]huh.Option[string], len(slotPaletteNames))
+		for i, name := range slotPaletteNames {
+			opts[i] = huh.NewOption(name, name)
+		}
+		fields := make([]huh.Field, absoluteMaxSlots)
+		for i := 0; i < absoluteMaxSlots; i++ {
+			slotNum := i + 1
+			fields[i] = huh.NewSelect[string]().
+				Title(fmt.Sprintf("Slot %d Color", slotNum)).
+				Description(fmt.Sprintf("Color used for the slot %d badge in the TUI. Waiting-on-input always shows yellow so you don't miss prompts.", slotNum)).
+				Options(opts...).
+				Value(&m.settingsDraft.slotColors[i])
+		}
+		return huh.NewForm(
+			huh.NewGroup(fields...),
 		).WithWidth(w).WithShowHelp(false).WithShowErrors(true)
 	}
 }
@@ -204,6 +224,12 @@ func (m *Model) handleSettingsCompleted() (tea.Model, tea.Cmd) {
 	newCfg.PostCreateHook = strings.TrimSpace(m.settingsDraft.hook)
 	newCfg.PromptTemplate = m.settingsDraft.prompt
 
+	slotColors := make([]string, absoluteMaxSlots)
+	for i := 0; i < absoluteMaxSlots; i++ {
+		slotColors[i] = m.settingsDraft.slotColors[i]
+	}
+	newCfg.SlotColors = slotColors
+
 	if newCfg.WorktreeBase == "" {
 		newCfg.WorktreeBase = "../worktrees"
 	}
@@ -214,7 +240,7 @@ func (m *Model) handleSettingsCompleted() (tea.Model, tea.Cmd) {
 		newCfg.BranchPrefix = "feature/"
 	}
 
-	m.settingsTabs = [3]*huh.Form{}
+	m.settingsTabs = [4]*huh.Form{}
 
 	oldKeys := make([]string, len(m.cfg.Teams))
 	for i, t := range m.cfg.Teams {
@@ -273,6 +299,9 @@ func (m *Model) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "3":
 		m.settingsActiveTab = 2
 		return m, nil
+	case "4":
+		m.settingsActiveTab = 3
+		return m, nil
 	case "ctrl+w":
 		if m.settingsActiveTab == 0 {
 			openBrowser("https://linear.app/settings")
@@ -289,7 +318,7 @@ func (m *Model) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.settingsFirstRun {
 			return m, nil
 		}
-		m.settingsTabs = [3]*huh.Form{}
+		m.settingsTabs = [4]*huh.Form{}
 		m.view = viewList
 		return m, nil
 	}
@@ -318,7 +347,7 @@ func (m *Model) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(cmd, initCmd)
 		}
 		if !m.settingsFirstRun {
-			m.settingsTabs = [3]*huh.Form{}
+			m.settingsTabs = [4]*huh.Form{}
 			m.view = viewList
 			return m, nil
 		}

--- a/model_state.go
+++ b/model_state.go
@@ -66,6 +66,7 @@ type Model struct {
 	list             list.Model
 	issues           []Issue
 	worktreeBranches map[string]bool
+	worktreePaths    map[string]string
 	filter           FilterMode
 	sortMode         SortMode
 	view             viewMode
@@ -238,6 +239,10 @@ func (m *Model) getBranchName(identifier string) string {
 
 func (m *Model) hasWorktree(identifier string) bool {
 	return m.worktreeBranches[m.getBranchName(identifier)]
+}
+
+func (m *Model) worktreePathFor(identifier string) string {
+	return m.worktreePaths[m.getBranchName(identifier)]
 }
 
 func (m *Model) selectedIssue() *Issue {

--- a/model_state.go
+++ b/model_state.go
@@ -46,6 +46,7 @@ type settingsDraft struct {
 	maxSlots   int
 	hook       string
 	prompt     string
+	slotColors [absoluteMaxSlots]string
 }
 
 type teamState struct {
@@ -101,8 +102,8 @@ type Model struct {
 	launchList  list.Model
 	promptArea  textarea.Model
 
-	settingsTabs      [3]*huh.Form
-	settingsTabNames  [3]string
+	settingsTabs      [4]*huh.Form
+	settingsTabNames  [4]string
 	settingsActiveTab int
 	settingsDraft     *settingsDraft
 	settingsFirstRun  bool
@@ -268,6 +269,7 @@ func (m *Model) rebuildList() {
 			if slot, _ := m.paneManager.FindSlotByIdentifier(issue.Identifier); slot != nil {
 				item.slotIdx = slot.Index
 				item.slotStatus = slot.Status
+				item.slotColor = m.cfg.SlotColorName(slot.Index)
 			}
 		}
 		items[i] = item

--- a/model_test.go
+++ b/model_test.go
@@ -393,6 +393,9 @@ func TestSettingsTabCount(t *testing.T) {
 	if m.settingsTabNames[2] != "Launch" {
 		t.Errorf("tab 2 name = %q, want 'Launch'", m.settingsTabNames[2])
 	}
+	if m.settingsTabNames[3] != "Slots" {
+		t.Errorf("tab 3 name = %q, want 'Slots'", m.settingsTabNames[3])
+	}
 }
 
 func TestSettingsActiveTab(t *testing.T) {

--- a/model_test.go
+++ b/model_test.go
@@ -153,8 +153,8 @@ func TestRemoveWorktreeConfirmDialog(t *testing.T) {
 	if model.confirm.action != confirmRemoveWorktree {
 		t.Errorf("expected confirmRemoveWorktree, got %d", model.confirm.action)
 	}
-	if !strings.Contains(model.confirm.message, "TEST-1") {
-		t.Errorf("expected message to mention TEST-1, got %q", model.confirm.message)
+	if !strings.Contains(model.confirm.message, "feature/test-1") {
+		t.Errorf("expected message to mention feature/test-1, got %q", model.confirm.message)
 	}
 }
 

--- a/model_theme.go
+++ b/model_theme.go
@@ -57,14 +57,14 @@ var (
 	// to adaptive colors. Light variants target WCAG AA on #F5F5F5; dark
 	// variants target visibility on #1E1E1E.
 	slotPaletteColors = map[string]compat.AdaptiveColor{
-		"green":  {Light: lipgloss.Color("#15803D"), Dark: lipgloss.Color("#22C55E")},
-		"blue":   {Light: lipgloss.Color("#2563EB"), Dark: lipgloss.Color("#3B82F6")},
+		"green":  greenColor,
+		"blue":   blueColor,
 		"purple": {Light: lipgloss.Color("#7C3AED"), Dark: lipgloss.Color("#A78BFA")},
-		"orange": {Light: lipgloss.Color("#C2410C"), Dark: lipgloss.Color("#F97316")},
+		"orange": orangeColor,
 		"pink":   {Light: lipgloss.Color("#BE185D"), Dark: lipgloss.Color("#EC4899")},
-		"cyan":   {Light: lipgloss.Color("#0E7490"), Dark: lipgloss.Color("#06B6D4")},
-		"yellow": {Light: lipgloss.Color("#B45309"), Dark: lipgloss.Color("#EAB308")},
-		"red":    {Light: lipgloss.Color("#B91C1C"), Dark: lipgloss.Color("#EF4444")},
+		"cyan":   identCyanColor,
+		"yellow": yellowColor,
+		"red":    redColor,
 	}
 
 	commentDimStyle = lipgloss.NewStyle().Foreground(dimColor)

--- a/model_theme.go
+++ b/model_theme.go
@@ -50,10 +50,22 @@ var (
 			Padding(1, 2).
 			Width(50)
 
-	slotRunningStyle = lipgloss.NewStyle().Foreground(greenColor)
 	slotWaitingStyle = lipgloss.NewStyle().Foreground(yellowColor)
-	slotIdleStyle    = lipgloss.NewStyle().Foreground(dimColor)
 	slotEmptyStyle   = lipgloss.NewStyle().Foreground(faintColor)
+
+	// slotPaletteColors maps palette names (see slotPaletteNames in config.go)
+	// to adaptive colors. Light variants target WCAG AA on #F5F5F5; dark
+	// variants target visibility on #1E1E1E.
+	slotPaletteColors = map[string]compat.AdaptiveColor{
+		"green":  {Light: lipgloss.Color("#15803D"), Dark: lipgloss.Color("#22C55E")},
+		"blue":   {Light: lipgloss.Color("#2563EB"), Dark: lipgloss.Color("#3B82F6")},
+		"purple": {Light: lipgloss.Color("#7C3AED"), Dark: lipgloss.Color("#A78BFA")},
+		"orange": {Light: lipgloss.Color("#C2410C"), Dark: lipgloss.Color("#F97316")},
+		"pink":   {Light: lipgloss.Color("#BE185D"), Dark: lipgloss.Color("#EC4899")},
+		"cyan":   {Light: lipgloss.Color("#0E7490"), Dark: lipgloss.Color("#06B6D4")},
+		"yellow": {Light: lipgloss.Color("#B45309"), Dark: lipgloss.Color("#EAB308")},
+		"red":    {Light: lipgloss.Color("#B91C1C"), Dark: lipgloss.Color("#EF4444")},
+	}
 
 	commentDimStyle = lipgloss.NewStyle().Foreground(dimColor)
 
@@ -70,3 +82,31 @@ var (
 				BorderForeground(faintColor).
 				Padding(0, 2)
 )
+
+// slotPaletteColor resolves a palette name to an AdaptiveColor. Unknown
+// names fall back to green.
+func slotPaletteColor(name string) compat.AdaptiveColor {
+	if c, ok := slotPaletteColors[name]; ok {
+		return c
+	}
+	return slotPaletteColors["green"]
+}
+
+// slotBadgeStyle returns the lipgloss style to render the status badge for the
+// given palette name and status. The badge is colored using the per-slot
+// palette (so different slots are visually distinct) except when the slot is
+// waiting on input -- that case forces the yellow waiting style so users
+// don't miss prompts.
+func slotBadgeStyle(paletteName string, status AgentStatus) lipgloss.Style {
+	if status == AgentWaiting {
+		return slotWaitingStyle
+	}
+	if status == AgentInactive {
+		return slotEmptyStyle
+	}
+	s := lipgloss.NewStyle().Foreground(slotPaletteColor(paletteName))
+	if status == AgentIdle {
+		s = s.Faint(true)
+	}
+	return s
+}

--- a/model_update.go
+++ b/model_update.go
@@ -284,7 +284,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case setupCompleteMsg:
 		m.cfg = msg.cfg
 		m.view = viewList
-		m.settingsTabs = [3]*huh.Form{}
+		m.settingsTabs = [4]*huh.Form{}
 		m.settingsFirstRun = false
 		m.statusMsg = "Settings saved. API key stored in OS keychain."
 		m.keys.TeamSwitch.SetEnabled(len(m.cfg.Teams) > 1)

--- a/model_update.go
+++ b/model_update.go
@@ -138,6 +138,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case worktreesLoadedMsg:
 		m.worktreeBranches = msg.branches
+		m.worktreePaths = msg.paths
 		m.rebuildList()
 		return m, nil
 
@@ -507,7 +508,7 @@ func (m *Model) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.confirm = &confirmDialog{
 			action:  confirmRemoveWorktree,
 			title:   "Remove Worktree?",
-			message: fmt.Sprintf("Remove worktree and branch for %s? This cannot be undone.", issue.Identifier),
+			message: BuildRemoveWorktreeMessage(m.worktreePathFor(issue.Identifier), fmt.Sprintf("for %s", issue.Identifier)),
 			onYes:   func(m *Model) (tea.Model, tea.Cmd) { return m.removeSelectedWorktree() },
 		}
 		return m, nil

--- a/model_update.go
+++ b/model_update.go
@@ -508,7 +508,7 @@ func (m *Model) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.confirm = &confirmDialog{
 			action:  confirmRemoveWorktree,
 			title:   "Remove Worktree?",
-			message: BuildRemoveWorktreeMessage(m.worktreePathFor(issue.Identifier), fmt.Sprintf("for %s", issue.Identifier)),
+			message: BuildRemoveWorktreeMessage(m.worktreePathFor(issue.Identifier), m.getBranchName(issue.Identifier)),
 			onYes:   func(m *Model) (tea.Model, tea.Cmd) { return m.removeSelectedWorktree() },
 		}
 		return m, nil

--- a/model_view.go
+++ b/model_view.go
@@ -342,5 +342,10 @@ func renderLegend() string {
 		priorityIcon(3) + " Medium  " +
 		priorityIcon(4) + " Low"
 
-	return statusLegend + "\n\n" + priorityLegend
+	slotLegend := heading.Render("Slots vs Worktrees") + "\n" +
+		"A slot is a cmux pane running Claude. A worktree is an on-disk git checkout.\n" +
+		"Closing a slot leaves the worktree intact. Removing a worktree closes any\n" +
+		"attached slot and deletes the branch."
+
+	return statusLegend + "\n\n" + priorityLegend + "\n\n" + slotLegend
 }

--- a/model_view.go
+++ b/model_view.go
@@ -271,7 +271,7 @@ func (m Model) viewSettings() string {
 	header := titleStyle.Render("Settings")
 	tabBar := m.renderSettingsTabBar()
 	body := m.activeSettingsForm().View()
-	helpText := "Tab: next field  Enter: save  1/2/3: switch tab"
+	helpText := "Tab: next field  Enter: save  1/2/3/4: switch tab"
 	if m.settingsFirstRun {
 		helpText += "  (complete setup to continue)"
 	} else {

--- a/model_view.go
+++ b/model_view.go
@@ -217,17 +217,7 @@ func (m Model) renderSlotBar() string {
 			continue
 		}
 
-		var style lipgloss.Style
-		switch slot.Status {
-		case AgentRunning:
-			style = slotRunningStyle
-		case AgentWaiting:
-			style = slotWaitingStyle
-		case AgentIdle:
-			style = slotIdleStyle
-		default:
-			style = slotEmptyStyle
-		}
+		style := slotBadgeStyle(m.cfg.SlotColorName(i), slot.Status)
 		parts[i] = style.Render(
 			fmt.Sprintf("[%d] %s %s (%s)", i+1, slot.Status.String(), slot.Issue.Identifier, slot.Status.Label()),
 		)

--- a/testdata/golden/list_demo_issues.txt
+++ b/testdata/golden/list_demo_issues.txt
@@ -3,7 +3,7 @@
     ENG > [Assigned to me]                                            
                                                                       
  │ ● ▲ ENG-142 Add rate limiting to public API endpoints              
- │ Alex | Platform Hardening | backend | security                     
+ │ Alex | Platform Hardening | Due in 2d | backend | security         
    ● ▲ ENG-138 Fix connection pool exhaustion under load              
    Alex | Platform Hardening | bug | backend                          
                                                                       

--- a/testdata/golden/settings_first_run.txt
+++ b/testdata/golden/settings_first_run.txt
@@ -1,6 +1,6 @@
   Settings                                                                                        
-   [1] Credentials    [2] Worktree    [3] Launch                                                  
- ─────────────────────────────────────────────────                                                
+   [1] Credentials    [2] Worktree    [3] Launch    [4] Slots                                     
+ ──────────────────────────────────────────────────────────────                                   
                                                                                                   
  ┃ Linear API Key                                                                                 
  ┃ Create one at: https://linear.app/settings                                                     

--- a/testdata/golden/settings_first_run.txt
+++ b/testdata/golden/settings_first_run.txt
@@ -12,4 +12,4 @@
    Add multiple teams separated by commas. First team is your default. Press 1-9 from the issue   
    list to switch between teams.                                                                  
                                                                                                   
-  Tab: next field  Enter: save  1/2/3/4: switch tab  (complete setup to continue)                   
+  Tab: next field  Enter: save  1/2/3/4: switch tab  (complete setup to continue)                 

--- a/testdata/golden/settings_first_run.txt
+++ b/testdata/golden/settings_first_run.txt
@@ -12,4 +12,4 @@
    Add multiple teams separated by commas. First team is your default. Press 1-9 from the issue   
    list to switch between teams.                                                                  
                                                                                                   
-  Tab: next field  Enter: save  1/2/3: switch tab  (complete setup to continue)                   
+  Tab: next field  Enter: save  1/2/3/4: switch tab  (complete setup to continue)                   

--- a/worktree.go
+++ b/worktree.go
@@ -130,7 +130,7 @@ func CreateWorktree(identifier string, cfg Config) (string, error) {
 // worktree. If wtPath is a dirty worktree, a warning line is prepended. An
 // empty wtPath skips the dirty check (used when the path is unknown).
 func BuildRemoveWorktreeMessage(wtPath, label string) string {
-	base := fmt.Sprintf("Remove worktree and branch %s? This cannot be undone.", label)
+	base := fmt.Sprintf("Remove worktree and branch %s? This cannot be undone.\n(The cmux slot will also be closed if open.)", label)
 	if wtPath == "" {
 		return base
 	}

--- a/worktree.go
+++ b/worktree.go
@@ -126,6 +126,72 @@ func CreateWorktree(identifier string, cfg Config) (string, error) {
 	return wtPath, nil
 }
 
+// BuildRemoveWorktreeMessage returns a confirm-dialog message for removing a
+// worktree. If wtPath is a dirty worktree, a warning line is prepended. An
+// empty wtPath skips the dirty check (used when the path is unknown).
+func BuildRemoveWorktreeMessage(wtPath, label string) string {
+	base := fmt.Sprintf("Remove worktree and branch %s? This cannot be undone.", label)
+	if wtPath == "" {
+		return base
+	}
+	dirty, summary, err := WorktreeDirty(wtPath)
+	if err != nil || !dirty {
+		return base
+	}
+	return fmt.Sprintf("WARNING: %s. This work will be lost.\n\n%s", summary, base)
+}
+
+// WorktreeDirty reports whether the worktree at wtPath has uncommitted changes,
+// untracked files, or unpushed commits. The summary string is a short,
+// human-readable description suitable for inclusion in a confirm dialog
+// (e.g. "3 uncommitted, 2 unpushed"). An empty summary means not dirty.
+func WorktreeDirty(wtPath string) (bool, string, error) {
+	if _, err := os.Stat(wtPath); err != nil {
+		return false, "", err
+	}
+
+	statusCmd := exec.Command("git", "status", "--porcelain")
+	statusCmd.Dir = wtPath
+	statusOut, err := statusCmd.Output()
+	if err != nil {
+		return false, "", fmt.Errorf("git status: %w", err)
+	}
+
+	uncommitted := 0
+	for _, line := range strings.Split(strings.TrimRight(string(statusOut), "\n"), "\n") {
+		if line != "" {
+			uncommitted++
+		}
+	}
+
+	// Best-effort unpushed check. A missing upstream is not an error: treat as
+	// zero unpushed for dialog purposes (the user will still see uncommitted
+	// counts and the branch will be deleted).
+	unpushed := 0
+	logCmd := exec.Command("git", "log", "@{u}..", "--oneline")
+	logCmd.Dir = wtPath
+	if logOut, logErr := logCmd.Output(); logErr == nil {
+		for _, line := range strings.Split(strings.TrimRight(string(logOut), "\n"), "\n") {
+			if line != "" {
+				unpushed++
+			}
+		}
+	}
+
+	if uncommitted == 0 && unpushed == 0 {
+		return false, "", nil
+	}
+
+	parts := []string{}
+	if uncommitted > 0 {
+		parts = append(parts, fmt.Sprintf("%d uncommitted", uncommitted))
+	}
+	if unpushed > 0 {
+		parts = append(parts, fmt.Sprintf("%d unpushed", unpushed))
+	}
+	return true, strings.Join(parts, ", "), nil
+}
+
 func RemoveWorktree(wtPath string) error {
 	root, err := FindRepoRoot()
 	if err != nil {

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -269,6 +270,69 @@ func TestRemoveWorktreeDeletesSlashBranch(t *testing.T) {
 	}
 	if len(out) != 0 {
 		t.Fatalf("branch feature/test-777 still exists after remove: %q", string(out))
+	}
+}
+
+func TestWorktreeDirty(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	worktreeBase := filepath.Join(t.TempDir(), "worktrees")
+	cfg := Config{
+		BranchPrefix: "feature/",
+		WorktreeBase: worktreeBase,
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Errorf("restore dir: %v", err)
+		}
+	}()
+
+	path, err := CreateWorktree("DIRTY-1", cfg)
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	// Clean worktree should report not dirty.
+	dirty, summary, err := WorktreeDirty(path)
+	if err != nil {
+		t.Fatalf("WorktreeDirty clean: %v", err)
+	}
+	if dirty {
+		t.Errorf("clean worktree reported dirty: %q", summary)
+	}
+
+	// Add an untracked file.
+	if err := os.WriteFile(filepath.Join(path, "new.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	dirty, summary, err = WorktreeDirty(path)
+	if err != nil {
+		t.Fatalf("WorktreeDirty untracked: %v", err)
+	}
+	if !dirty {
+		t.Errorf("worktree with untracked file not reported dirty")
+	}
+	if !strings.Contains(summary, "uncommitted") {
+		t.Errorf("summary %q should mention uncommitted", summary)
+	}
+}
+
+func TestBuildRemoveWorktreeMessage(t *testing.T) {
+	// Empty path skips dirty check.
+	msg := BuildRemoveWorktreeMessage("", "feature/foo")
+	if !strings.Contains(msg, "feature/foo") {
+		t.Errorf("message missing label: %q", msg)
+	}
+	if strings.Contains(msg, "WARNING") {
+		t.Errorf("empty path should not produce warning: %q", msg)
 	}
 }
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -336,6 +336,42 @@ func TestBuildRemoveWorktreeMessage(t *testing.T) {
 	}
 }
 
+func TestBuildRemoveWorktreeMessageDirty(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	worktreeBase := filepath.Join(t.TempDir(), "worktrees")
+	cfg := Config{
+		BranchPrefix: "feature/",
+		WorktreeBase: worktreeBase,
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	path, err := CreateWorktree("DIRTY-MSG", cfg)
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	// Make it dirty with an untracked file.
+	if err := os.WriteFile(filepath.Join(path, "new.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	msg := BuildRemoveWorktreeMessage(path, "feature/dirty-msg")
+	if !strings.Contains(msg, "WARNING") {
+		t.Errorf("dirty worktree should produce WARNING: %q", msg)
+	}
+	if !strings.Contains(msg, "uncommitted") {
+		t.Errorf("warning should mention uncommitted: %q", msg)
+	}
+}
+
 func TestCopyFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	src := filepath.Join(tmpDir, "source.txt")


### PR DESCRIPTION
## Summary

Four worktree workflow improvements from serabi/linear-worktree#46, tackled as atomic commits:

- **#41** — Widen `inferStatus` read window from 5 to 20 lines so Claude Code permission prompts aren't missed when they scroll above the last few terminal lines.
- **#42** — Check for uncommitted changes, untracked files, and unpushed commits before running `git worktree remove --force`. When dirty, prepend a warning line to the confirm dialog so users notice work that would be lost.
- **#43** — Clarify slot vs worktree lifecycle in UI copy: a new "Slots vs Worktrees" legend in the help view, a reminder in the remove-worktree confirm that the attached slot will also close, and a `slot N ·` prefix on worktree-list rows that have a slot attached.
- **#32** — Per-slot color customization. Users pick from a named palette (green/blue/purple/orange/pink/cyan/yellow/red) via a new "Slots" settings tab, so different slots are visually distinct. Waiting-on-input still overrides to yellow so users don't miss permission prompts.

Closes #41, #42, #43, #32.

## Test plan

- [x] `go test ./...` passes
- [x] Golden snapshot for settings updated (new "Slots" tab label)
- [x] New tests: `TestWorktreeDirty`, `TestBuildRemoveWorktreeMessage`, `TestSlotColorName`
- [ ] Manual: open TUI, create two worktrees, confirm slot badges show configured per-slot colors
- [ ] Manual: leave uncommitted changes in a worktree, press `x`, confirm warning line appears
- [ ] Manual: open `?` help, confirm "Slots vs Worktrees" legend renders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Slots" settings tab to configure per-slot colors.
  * Worktree removal dialog now warns when a worktree has uncommitted or unpushed changes.

* **Improvements**
  * More reliable agent status detection by scanning recent terminal output line-by-line.
  * Expanded slot color palette, unified slot badge styling, and updated legend to include "Slots vs Worktrees".

* **Tests**
  * Added tests for slot color resolution and worktree dirty/warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->