### PR TITLE
fix(launcher): shell-quote claude_args to handle spaces and special chars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/term v0.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=

--- a/launcher.go
+++ b/launcher.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"strings"
 	"text/template"
+
+	"github.com/google/shlex"
 )
 
 func LaunchClaude(wtPath string, issue Issue, cfg Config) error {
@@ -73,7 +75,14 @@ func buildPrompt(issue Issue, cfg Config) string {
 func buildShellCmd(prompt string, cfg Config) string {
 	parts := []string{cfg.ClaudeCommand}
 	if cfg.ClaudeArgs != "" {
-		parts = append(parts, cfg.ClaudeArgs)
+		tokens, err := shlex.Split(cfg.ClaudeArgs)
+		if err != nil {
+			debugLog.Printf("claude_args parse error: %v", err)
+			tokens = strings.Fields(cfg.ClaudeArgs)
+		}
+		for _, tok := range tokens {
+			parts = append(parts, shellQuote(tok))
+		}
 	}
 	if prompt != "" {
 		parts = append(parts, shellQuote(prompt))

--- a/launcher_test.go
+++ b/launcher_test.go
@@ -1,0 +1,64 @@
+package main
+
+import "testing"
+
+func TestBuildShellCmd(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    Config
+		prompt string
+		want   string
+	}{
+		{
+			name:   "no args no prompt",
+			cfg:    Config{ClaudeCommand: "claude"},
+			prompt: "",
+			want:   "claude",
+		},
+		{
+			name:   "no args with prompt",
+			cfg:    Config{ClaudeCommand: "claude"},
+			prompt: "hello",
+			want:   "claude 'hello'",
+		},
+		{
+			name:   "simple args",
+			cfg:    Config{ClaudeCommand: "claude", ClaudeArgs: "--model sonnet"},
+			prompt: "hi",
+			want:   "claude '--model' 'sonnet' 'hi'",
+		},
+		{
+			name:   "arg with quoted spaces",
+			cfg:    Config{ClaudeCommand: "claude", ClaudeArgs: `--system-prompt "be concise"`},
+			prompt: "hi",
+			want:   "claude '--system-prompt' 'be concise' 'hi'",
+		},
+		{
+			name:   "arg containing single quote via double quotes",
+			cfg:    Config{ClaudeCommand: "claude", ClaudeArgs: `--flag "it's fine"`},
+			prompt: "",
+			want:   `claude '--flag' 'it'\''s fine'`,
+		},
+		{
+			name:   "arg with special shell chars",
+			cfg:    Config{ClaudeCommand: "claude", ClaudeArgs: `--opt "$HOME; rm -rf /"`},
+			prompt: "",
+			want:   `claude '--opt' '$HOME; rm -rf /'`,
+		},
+		{
+			name:   "unterminated quote falls back to fields",
+			cfg:    Config{ClaudeCommand: "claude", ClaudeArgs: `--bad "unterminated`},
+			prompt: "",
+			want:   `claude '--bad' '"unterminated'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildShellCmd(tt.prompt, tt.cfg)
+			if got != tt.want {
+				t.Errorf("buildShellCmd() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `buildShellCmd` concatenated `ClaudeArgs` as a raw string between the command and the prompt, so arguments like `--system-prompt "be concise"` relied on the downstream shell re-parsing them intact
- Parse `ClaudeArgs` with `shlex` and requote each token individually via the existing `shellQuote` helper, making the quoting explicit and robust to shell metacharacters
- Fall back to `strings.Fields` on parse error (e.g. unterminated quotes) so a malformed config still launches, with a debug log

Closes #44

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] New `launcher_test.go` covers: no args, simple args, args with quoted spaces, embedded single quotes, shell metacharacters, and the unterminated-quote fallback