### PR TITLE
test: add coverage for worktree workflows (closes #45)

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -92,9 +92,20 @@ const (
 	LayoutGrid                      // 4 slots: 2x2 grid on the right
 )
 
+// cmuxIO is the subset of CmuxClient methods PaneManager depends on.
+// Extracting it as an interface lets tests substitute a fake without
+// opening a real Unix socket.
+type cmuxIO interface {
+	SplitSurface(workspaceID, surfaceID, direction string) (string, error)
+	CloseSurface(workspaceID, surfaceID string) error
+	SendText(workspaceID, surfaceID, text string) error
+	ReadText(workspaceID, surfaceID string, lines int) (string, error)
+	FocusSurface(workspaceID, surfaceID string) error
+}
+
 // PaneManager tracks the E-layout state.
 type PaneManager struct {
-	client      *CmuxClient
+	client      cmuxIO
 	workspaceID string
 	tuiSurface  string // left pane (the TUI)
 	slots       [absoluteMaxSlots]*WorktreeSlot
@@ -215,7 +226,7 @@ func (c *CmuxClient) FocusSurface(workspaceID, surfaceID string) error {
 
 // --- PaneManager ---
 
-func NewPaneManager(client *CmuxClient, maxSlots int) *PaneManager {
+func NewPaneManager(client cmuxIO, maxSlots int) *PaneManager {
 	if maxSlots < 2 || maxSlots > absoluteMaxSlots {
 		maxSlots = defaultMaxSlots
 	}

--- a/cmux_test.go
+++ b/cmux_test.go
@@ -8,6 +8,57 @@ import (
 	"testing"
 )
 
+// fakeCmuxIO is a recording fake implementing cmuxIO for tests. It never
+// touches a socket or subprocess.
+type fakeCmuxIO struct {
+	splitCalls  []struct{ ws, sf, dir string }
+	closeCalls  []struct{ ws, sf string }
+	sendCalls   []struct{ ws, sf, text string }
+	readCalls   []struct {
+		ws, sf string
+		lines  int
+	}
+	focusCalls []struct{ ws, sf string }
+
+	splitReturns func(ws, sf, dir string) (string, error)
+	readReturns  func(ws, sf string, lines int) (string, error)
+	closeErr     error
+}
+
+func (f *fakeCmuxIO) SplitSurface(ws, sf, dir string) (string, error) {
+	f.splitCalls = append(f.splitCalls, struct{ ws, sf, dir string }{ws, sf, dir})
+	if f.splitReturns != nil {
+		return f.splitReturns(ws, sf, dir)
+	}
+	return "new-surface", nil
+}
+
+func (f *fakeCmuxIO) CloseSurface(ws, sf string) error {
+	f.closeCalls = append(f.closeCalls, struct{ ws, sf string }{ws, sf})
+	return f.closeErr
+}
+
+func (f *fakeCmuxIO) SendText(ws, sf, text string) error {
+	f.sendCalls = append(f.sendCalls, struct{ ws, sf, text string }{ws, sf, text})
+	return nil
+}
+
+func (f *fakeCmuxIO) ReadText(ws, sf string, lines int) (string, error) {
+	f.readCalls = append(f.readCalls, struct {
+		ws, sf string
+		lines  int
+	}{ws, sf, lines})
+	if f.readReturns != nil {
+		return f.readReturns(ws, sf, lines)
+	}
+	return "", nil
+}
+
+func (f *fakeCmuxIO) FocusSurface(ws, sf string) error {
+	f.focusCalls = append(f.focusCalls, struct{ ws, sf string }{ws, sf})
+	return nil
+}
+
 // withFakeCmux installs a shell script named "cmux" into a temp dir and
 // prepends that dir to PATH for the duration of the test. The script
 // prints scriptBody to stdout and exits with exitCode.
@@ -393,5 +444,163 @@ func TestInferStatusScrolledPrompt(t *testing.T) {
 	// inferStatus should still detect the ❯ character anywhere in the blob.
 	if got := inferStatus(text); got != AgentIdle {
 		t.Errorf("inferStatus with scrolled ❯ = %v, want AgentIdle", got.Label())
+	}
+}
+
+func TestCloseSlotBoundsCheck(t *testing.T) {
+	fake := &fakeCmuxIO{}
+	pm := &PaneManager{client: fake, maxSlots: 3, workspaceID: "ws"}
+
+	tests := []struct {
+		name string
+		idx  int
+	}{
+		{"negative", -1},
+		{"equal to maxSlots", 3},
+		{"beyond maxSlots", 99},
+		{"valid but empty", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := pm.CloseSlot(tt.idx); err == nil {
+				t.Errorf("CloseSlot(%d) returned nil error, expected failure", tt.idx)
+			}
+		})
+	}
+	if len(fake.closeCalls) != 0 {
+		t.Errorf("CloseSurface should not be called on bounds failure, got %d calls", len(fake.closeCalls))
+	}
+}
+
+func TestCloseSlotFreesSlot(t *testing.T) {
+	fake := &fakeCmuxIO{}
+	pm := &PaneManager{client: fake, maxSlots: 3, workspaceID: "ws"}
+	pm.slots[1] = &WorktreeSlot{Index: 1, SurfaceID: "surf-1"}
+
+	if err := pm.CloseSlot(1); err != nil {
+		t.Fatalf("CloseSlot: %v", err)
+	}
+	if pm.slots[1] != nil {
+		t.Error("slot 1 should be nil after close")
+	}
+	if len(fake.closeCalls) != 1 {
+		t.Fatalf("expected 1 CloseSurface call, got %d", len(fake.closeCalls))
+	}
+	if fake.closeCalls[0].sf != "surf-1" {
+		t.Errorf("CloseSurface surface = %q, want surf-1", fake.closeCalls[0].sf)
+	}
+}
+
+// TestCloseSlotPreservesWorktreeOnDisk verifies the slot/worktree lifecycle
+// distinction (see PR #43): closing a cmux slot must not remove the
+// worktree directory from disk.
+func TestCloseSlotPreservesWorktreeOnDisk(t *testing.T) {
+	wtDir := t.TempDir()
+	marker := filepath.Join(wtDir, "keep-me.txt")
+	if err := os.WriteFile(marker, []byte("x"), 0644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	fake := &fakeCmuxIO{}
+	pm := &PaneManager{client: fake, maxSlots: 3, workspaceID: "ws"}
+	pm.slots[0] = &WorktreeSlot{
+		Index:        0,
+		SurfaceID:    "s0",
+		WorktreePath: wtDir,
+	}
+
+	if err := pm.CloseSlot(0); err != nil {
+		t.Fatalf("CloseSlot: %v", err)
+	}
+	if _, err := os.Stat(wtDir); err != nil {
+		t.Errorf("worktree dir should still exist after CloseSlot: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("worktree contents should be untouched: %v", err)
+	}
+}
+
+func TestCloseSlotPropagatesError(t *testing.T) {
+	fake := &fakeCmuxIO{closeErr: fmt.Errorf("socket closed")}
+	pm := &PaneManager{client: fake, maxSlots: 3, workspaceID: "ws"}
+	pm.slots[0] = &WorktreeSlot{Index: 0, SurfaceID: "s0"}
+
+	err := pm.CloseSlot(0)
+	if err == nil || !strings.Contains(err.Error(), "socket closed") {
+		t.Errorf("CloseSlot err = %v, want 'socket closed'", err)
+	}
+	// Slot should still be freed even on error (current behavior).
+	if pm.slots[0] != nil {
+		t.Error("slot should be freed even when CloseSurface errors")
+	}
+}
+
+func TestPollStatusUpdatesPerSlot(t *testing.T) {
+	perSurface := map[string]string{
+		"s0": "some output\nctrl+c to interrupt",      // running
+		"s1": "Allow this action? [y/n]",              // waiting
+		"s2": "done\n❯ ",                              // idle
+	}
+	fake := &fakeCmuxIO{
+		readReturns: func(ws, sf string, lines int) (string, error) {
+			return perSurface[sf], nil
+		},
+	}
+	pm := &PaneManager{client: fake, maxSlots: 3, workspaceID: "ws"}
+	pm.slots[0] = &WorktreeSlot{Index: 0, SurfaceID: "s0", Status: AgentInactive}
+	pm.slots[1] = &WorktreeSlot{Index: 1, SurfaceID: "s1", Status: AgentInactive}
+	pm.slots[2] = &WorktreeSlot{Index: 2, SurfaceID: "s2", Status: AgentInactive}
+
+	pm.PollStatus()
+
+	wantStatuses := []AgentStatus{AgentRunning, AgentWaiting, AgentIdle}
+	for i, want := range wantStatuses {
+		if pm.slots[i].Status != want {
+			t.Errorf("slot[%d].Status = %v, want %v", i, pm.slots[i].Status.Label(), want.Label())
+		}
+	}
+	// ReadText should be called once per occupied slot with the expected window.
+	if len(fake.readCalls) != 3 {
+		t.Fatalf("got %d ReadText calls, want 3", len(fake.readCalls))
+	}
+	for _, call := range fake.readCalls {
+		if call.lines != statusReadLines {
+			t.Errorf("ReadText lines = %d, want %d", call.lines, statusReadLines)
+		}
+	}
+}
+
+func TestPollStatusSkipsEmptySlots(t *testing.T) {
+	fake := &fakeCmuxIO{
+		readReturns: func(ws, sf string, lines int) (string, error) {
+			return "❯ ", nil
+		},
+	}
+	pm := &PaneManager{client: fake, maxSlots: 3, workspaceID: "ws"}
+	pm.slots[1] = &WorktreeSlot{Index: 1, SurfaceID: "s1", Status: AgentInactive}
+
+	pm.PollStatus()
+
+	if len(fake.readCalls) != 1 {
+		t.Fatalf("got %d ReadText calls, want 1 (only slot 1 occupied)", len(fake.readCalls))
+	}
+	if fake.readCalls[0].sf != "s1" {
+		t.Errorf("ReadText surface = %q, want s1", fake.readCalls[0].sf)
+	}
+}
+
+func TestPollStatusReadErrorDoesNotChangeStatus(t *testing.T) {
+	fake := &fakeCmuxIO{
+		readReturns: func(ws, sf string, lines int) (string, error) {
+			return "", fmt.Errorf("read failed")
+		},
+	}
+	pm := &PaneManager{client: fake, maxSlots: 3, workspaceID: "ws"}
+	pm.slots[0] = &WorktreeSlot{Index: 0, SurfaceID: "s0", Status: AgentRunning}
+
+	pm.PollStatus()
+
+	if pm.slots[0].Status != AgentRunning {
+		t.Errorf("status should be unchanged on read error, got %v", pm.slots[0].Status.Label())
 	}
 }

--- a/cmux_test.go
+++ b/cmux_test.go
@@ -1,8 +1,34 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// withFakeCmux installs a shell script named "cmux" into a temp dir and
+// prepends that dir to PATH for the duration of the test. The script
+// prints scriptBody to stdout and exits with exitCode.
+func withFakeCmux(t *testing.T, scriptBody string, exitCode int) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n"
+	if scriptBody != "" {
+		script += "cat <<'EOF'\n" + scriptBody + "\nEOF\n"
+	}
+	if exitCode != 0 {
+		script += fmt.Sprintf("exit %d\n", exitCode)
+	}
+	path := filepath.Join(dir, "cmux")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake cmux: %v", err)
+	}
+	// Prepend the fake dir to the real PATH so /bin/sh and other utilities
+	// remain discoverable for the shebang and cat heredoc.
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
 
 func TestAgentStatusString(t *testing.T) {
 	tests := []struct {
@@ -271,5 +297,101 @@ func TestContainsAny(t *testing.T) {
 	}
 	if containsAny("", "anything") {
 		t.Error("empty string should not contain anything")
+	}
+}
+
+func TestCmuxIdentify(t *testing.T) {
+	tests := []struct {
+		name         string
+		scriptBody   string
+		exitCode     int
+		wantErr      bool
+		wantWorkspace string
+		wantSurface  string
+	}{
+		{
+			name:          "valid identify output",
+			scriptBody:    `{"caller":{"workspace_ref":"ws-123","surface_ref":"sf-456"}}`,
+			wantWorkspace: "ws-123",
+			wantSurface:   "sf-456",
+		},
+		{
+			name:       "missing caller field",
+			scriptBody: `{"other":"data"}`,
+			wantErr:    true,
+		},
+		{
+			name:       "malformed json",
+			scriptBody: `not json {{{`,
+			wantErr:    true,
+		},
+		{
+			name:       "non-zero exit",
+			scriptBody: `{"caller":{"workspace_ref":"ws","surface_ref":"sf"}}`,
+			exitCode:   1,
+			wantErr:    true,
+		},
+		{
+			name:          "extra fields ignored",
+			scriptBody:    `{"caller":{"workspace_ref":"w","surface_ref":"s","extra":"ignored"},"version":"1.0"}`,
+			wantWorkspace: "w",
+			wantSurface:   "s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withFakeCmux(t, tt.scriptBody, tt.exitCode)
+			result, err := cmuxIdentify()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (result=%+v)", result)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.workspaceRef != tt.wantWorkspace {
+				t.Errorf("workspaceRef = %q, want %q", result.workspaceRef, tt.wantWorkspace)
+			}
+			if result.surfaceRef != tt.wantSurface {
+				t.Errorf("surfaceRef = %q, want %q", result.surfaceRef, tt.wantSurface)
+			}
+		})
+	}
+}
+
+func TestCmuxIdentifyNotOnPath(t *testing.T) {
+	// Empty PATH: cmux lookup should fail.
+	t.Setenv("PATH", t.TempDir())
+	if _, err := cmuxIdentify(); err == nil {
+		t.Fatal("expected error when cmux not on PATH")
+	}
+}
+
+func TestStatusReadLinesConstant(t *testing.T) {
+	// The window must be wide enough to catch Claude Code prompts that
+	// scroll above the last few lines (see PR #41). 20 is the current value;
+	// dropping below 20 should be a deliberate decision.
+	if statusReadLines < 20 {
+		t.Errorf("statusReadLines = %d, must be >= 20 to catch scrolled prompts", statusReadLines)
+	}
+}
+
+func TestInferStatusScrolledPrompt(t *testing.T) {
+	// When Claude Code's prompt scrolls above the last few lines, the 20-line
+	// read window must still include it. Simulate a buffer where the prompt
+	// appears several lines above the bottom.
+	var lines []string
+	lines = append(lines, "❯ finished editing file.go")
+	for i := 0; i < 15; i++ {
+		lines = append(lines, fmt.Sprintf("output line %d", i))
+	}
+	text := strings.Join(lines, "\n")
+
+	// inferStatus should still detect the ❯ character anywhere in the blob.
+	if got := inferStatus(text); got != AgentIdle {
+		t.Errorf("inferStatus with scrolled ❯ = %v, want AgentIdle", got.Label())
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -1430,5 +1430,152 @@ func TestBuildLaunchOptionsNilPaneManager(t *testing.T) {
 	}
 }
 
+func TestLaunchWithPromptCmdSuccess(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	worktreeBase := filepath.Join(t.TempDir(), "worktrees")
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	markerDir := t.TempDir()
+	markerPath := filepath.Join(markerDir, "hook-ran")
+
+	m := NewModel(Config{
+		BranchPrefix:   "feature/",
+		WorktreeBase:   worktreeBase,
+		ClaudeCommand:  "claude",
+		PostCreateHook: "touch " + markerPath,
+	})
+
+	issue := Issue{Identifier: "LWPC-1", Title: "Launch with prompt test"}
+	cmd := m.launchWithPromptCmd(issue, "hello prompt")
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	msg := cmd()
+
+	ready, ok := msg.(launchReadyMsg)
+	if !ok {
+		t.Fatalf("got %T, want launchReadyMsg", msg)
+	}
+	if ready.issue.Identifier != "LWPC-1" {
+		t.Errorf("issue.Identifier = %q, want LWPC-1", ready.issue.Identifier)
+	}
+	if ready.prompt != "hello prompt" {
+		t.Errorf("prompt = %q, want 'hello prompt'", ready.prompt)
+	}
+	if ready.hookErr != nil {
+		t.Errorf("hookErr = %v, want nil", ready.hookErr)
+	}
+	wantPath := filepath.Join(worktreeBase, "lwpc-1")
+	if normalizePath(ready.wtPath) != normalizePath(wantPath) {
+		t.Errorf("wtPath = %q, want %q", ready.wtPath, wantPath)
+	}
+	if _, err := os.Stat(ready.wtPath); err != nil {
+		t.Errorf("worktree should exist on disk: %v", err)
+	}
+	// Hook ran with wtPath as cwd — marker is at absolute path, so it exists.
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Errorf("post-create hook marker missing: %v", err)
+	}
+}
+
+func TestLaunchWithPromptCmdHookFailure(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	worktreeBase := filepath.Join(t.TempDir(), "worktrees")
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	m := NewModel(Config{
+		BranchPrefix:   "feature/",
+		WorktreeBase:   worktreeBase,
+		ClaudeCommand:  "claude",
+		PostCreateHook: "exit 7",
+	})
+
+	issue := Issue{Identifier: "LWPC-2", Title: "Hook failure"}
+	msg := m.launchWithPromptCmd(issue, "")()
+
+	ready, ok := msg.(launchReadyMsg)
+	if !ok {
+		t.Fatalf("got %T, want launchReadyMsg", msg)
+	}
+	if ready.hookErr == nil {
+		t.Error("expected hookErr, got nil")
+	}
+	// Worktree should still be created despite hook failure.
+	if _, err := os.Stat(ready.wtPath); err != nil {
+		t.Errorf("worktree should exist even when hook fails: %v", err)
+	}
+	if ready.issue.Identifier != "LWPC-2" {
+		t.Errorf("issue.Identifier = %q, want LWPC-2", ready.issue.Identifier)
+	}
+}
+
+func TestLaunchWithPromptCmdCreateFailure(t *testing.T) {
+	// Run from a non-git directory so FindRepoRoot fails.
+	nonGit := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(nonGit); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	m := NewModel(Config{
+		BranchPrefix: "feature/",
+		WorktreeBase: filepath.Join(nonGit, "wt"),
+	})
+
+	msg := m.launchWithPromptCmd(Issue{Identifier: "LWPC-3"}, "")()
+	created, ok := msg.(worktreeCreatedMsg)
+	if !ok {
+		t.Fatalf("got %T, want worktreeCreatedMsg on create failure", msg)
+	}
+	if created.err == nil {
+		t.Error("expected err, got nil")
+	}
+	if created.identifier != "LWPC-3" {
+		t.Errorf("identifier = %q, want LWPC-3", created.identifier)
+	}
+}
+
+// TestWorktreeCreatedMsgHookErrorWKey covers the w-key path: when the user
+// creates a worktree without launching (via createSelectedWorktree), a failed
+// post-create hook produces a worktreeCreatedMsg whose status line is
+// different from the launch path. See PR #40.
+func TestWorktreeCreatedMsgHookErrorWKey(t *testing.T) {
+	m := NewModel(Config{
+		ClaudeCommand: "claude",
+		WorktreeBase:  "/tmp/wt",
+		BranchPrefix:  "feature/",
+	})
+
+	result, _ := m.Update(worktreeCreatedMsg{
+		path:       "/tmp/wt/test-1",
+		identifier: "TEST-1",
+		hookErr:    errors.New("npm install failed"),
+	})
+	model := result.(Model)
+
+	// The w-key status message format: "Worktree created: ... (hook failed: ...)"
+	if !strings.Contains(model.statusMsg, "hook failed") {
+		t.Errorf("statusMsg should mention hook failure, got %q", model.statusMsg)
+	}
+	if !strings.Contains(model.statusMsg, "Worktree created") {
+		t.Errorf("statusMsg should mention Worktree created, got %q", model.statusMsg)
+	}
+	// Distinct from the launch-path message which starts with "Warning:".
+	if strings.HasPrefix(model.statusMsg, "Warning:") {
+		t.Errorf("w-key path should not use Warning: prefix (launch path does), got %q", model.statusMsg)
+	}
+}
+
 // Ensure huh is used (compile-time check)
 var _ = huh.StateCompleted

--- a/model_test.go
+++ b/model_test.go
@@ -1345,5 +1345,90 @@ func TestRelativeTimeUntil(t *testing.T) {
 	}
 }
 
+func TestBuildLaunchOptions(t *testing.T) {
+	issue := &Issue{Identifier: "TEST-42", Title: "Thing"}
+
+	tests := []struct {
+		name        string
+		hasSlot     bool
+		slotStatus  AgentStatus
+		hasWorktree bool
+		wantActions []string
+	}{
+		{
+			name:        "neither slot nor worktree",
+			wantActions: []string{"prompt", "blank"},
+		},
+		{
+			name:        "worktree only (no slot)",
+			hasWorktree: true,
+			wantActions: []string{"prompt", "blank", "existing"},
+		},
+		{
+			name:        "slot only (no worktree)",
+			hasSlot:     true,
+			slotStatus:  AgentRunning,
+			wantActions: []string{"resume", "prompt", "blank"},
+		},
+		{
+			name:        "both slot and worktree suppresses existing",
+			hasSlot:     true,
+			slotStatus:  AgentIdle,
+			hasWorktree: true,
+			wantActions: []string{"resume", "prompt", "blank"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel(Config{BranchPrefix: "feature/"})
+			m.paneManager = &PaneManager{maxSlots: 3}
+			if tt.hasSlot {
+				m.paneManager.slots[1] = &WorktreeSlot{
+					Index:  1,
+					Issue:  *issue,
+					Status: tt.slotStatus,
+				}
+			}
+			if tt.hasWorktree {
+				m.worktreeBranches = map[string]bool{"feature/test-42": true}
+			}
+
+			items := m.buildLaunchOptions(issue)
+			if len(items) != len(tt.wantActions) {
+				t.Fatalf("got %d items, want %d: %+v", len(items), len(tt.wantActions), items)
+			}
+			for i, item := range items {
+				opt, ok := item.(launchOption)
+				if !ok {
+					t.Fatalf("item[%d] is %T, want launchOption", i, item)
+				}
+				if opt.action != tt.wantActions[i] {
+					t.Errorf("item[%d].action = %q, want %q", i, opt.action, tt.wantActions[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildLaunchOptionsNilPaneManager(t *testing.T) {
+	m := NewModel(Config{BranchPrefix: "feature/"})
+	m.paneManager = nil
+	m.worktreeBranches = map[string]bool{"feature/test-1": true}
+
+	items := m.buildLaunchOptions(&Issue{Identifier: "TEST-1"})
+	// With nil paneManager: no resume option, worktree still detected.
+	wantActions := []string{"prompt", "blank", "existing"}
+	if len(items) != len(wantActions) {
+		t.Fatalf("got %d items, want %d", len(items), len(wantActions))
+	}
+	for i, item := range items {
+		opt := item.(launchOption)
+		if opt.action != wantActions[i] {
+			t.Errorf("item[%d].action = %q, want %q", i, opt.action, wantActions[i])
+		}
+	}
+}
+
 // Ensure huh is used (compile-time check)
 var _ = huh.StateCompleted

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -336,18 +336,61 @@ func TestBuildRemoveWorktreeMessage(t *testing.T) {
 	}
 }
 
+func TestWorktreeDirtyModifiedTrackedFile(t *testing.T) {
+	repoDir := setupTestRepo(t)
+	worktreeBase := filepath.Join(t.TempDir(), "worktrees")
+	cfg := Config{BranchPrefix: "feature/", WorktreeBase: worktreeBase}
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Add and commit a tracked file in the main repo so the worktree inherits it.
+	tracked := filepath.Join(repoDir, "tracked.txt")
+	if err := os.WriteFile(tracked, []byte("original"), 0644); err != nil {
+		t.Fatalf("write tracked: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "tracked.txt"},
+		{"git", "commit", "-m", "add tracked"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s", args, string(out))
+		}
+	}
+
+	path, err := CreateWorktree("DIRTY-MOD", cfg)
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	// Modify the tracked file in the worktree.
+	if err := os.WriteFile(filepath.Join(path, "tracked.txt"), []byte("modified"), 0644); err != nil {
+		t.Fatalf("modify file: %v", err)
+	}
+
+	dirty, summary, err := WorktreeDirty(path)
+	if err != nil {
+		t.Fatalf("WorktreeDirty: %v", err)
+	}
+	if !dirty {
+		t.Error("modified tracked file should be dirty")
+	}
+	if !strings.Contains(summary, "uncommitted") {
+		t.Errorf("summary %q should mention uncommitted", summary)
+	}
+}
+
 func TestBuildRemoveWorktreeMessageDirty(t *testing.T) {
 	repoDir := setupTestRepo(t)
 	worktreeBase := filepath.Join(t.TempDir(), "worktrees")
-	cfg := Config{
-		BranchPrefix: "feature/",
-		WorktreeBase: worktreeBase,
-	}
+	cfg := Config{BranchPrefix: "feature/", WorktreeBase: worktreeBase}
 
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
+	origDir, _ := os.Getwd()
 	if err := os.Chdir(repoDir); err != nil {
 		t.Fatalf("chdir: %v", err)
 	}
@@ -357,18 +400,26 @@ func TestBuildRemoveWorktreeMessageDirty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
-
-	// Make it dirty with an untracked file.
-	if err := os.WriteFile(filepath.Join(path, "new.txt"), []byte("x"), 0644); err != nil {
-		t.Fatalf("write file: %v", err)
+	if err := os.WriteFile(filepath.Join(path, "unsaved.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
 	}
 
 	msg := BuildRemoveWorktreeMessage(path, "feature/dirty-msg")
 	if !strings.Contains(msg, "WARNING") {
-		t.Errorf("dirty worktree should produce WARNING: %q", msg)
+		t.Errorf("dirty worktree message missing WARNING: %q", msg)
 	}
 	if !strings.Contains(msg, "uncommitted") {
-		t.Errorf("warning should mention uncommitted: %q", msg)
+		t.Errorf("message should mention uncommitted count: %q", msg)
+	}
+	if !strings.Contains(msg, "feature/dirty-msg") {
+		t.Errorf("message missing label: %q", msg)
+	}
+}
+
+func TestWorktreeDirtyNonExistentPath(t *testing.T) {
+	_, _, err := WorktreeDirty("/nonexistent/path/should/not/exist")
+	if err == nil {
+		t.Error("expected error for nonexistent path")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds test coverage for worktree workflow code paths that were previously untested. Stacked on top of #feat/worktree-medium-issues — rebase this onto main after the parent merges.

Target functions covered:
- buildLaunchOptions (launch option set logic)
- PollStatus (cycle + 20-line read window from #41)
- CloseSlot (slot vs worktree lifecycle, per #43)
- cmuxIdentify (JSON parsing + error paths)
- launchWithPromptCmd (end-to-end: worktree create + hook + launchReadyMsg)
- Hook error propagation (distinct w vs c key path messages, from #40)
- Dirty-worktree check (from #42)

## Approach

- Table-driven tests throughout
- Real temp dirs + git init for filesystem/git work
- Fake shell scripts on PATH for cmux binary lookups
- Small refactor: extract cmuxIO interface on PaneManager so CloseSlot/PollStatus can be tested without a real Unix socket

## Commits

1. refactor(cmux): extract cmuxIO interface for PaneManager
2. test(cmux): cover cmuxIdentify parsing and inferStatus window
3. test(launch): cover buildLaunchOptions option set
4. test(cmux): cover CloseSlot lifecycle and PollStatus cycle
5. test(launch): cover launchWithPromptCmd and w-key hook error
6. test(worktree): extend dirty-worktree coverage

## Test plan

- [x] go test ./... passes
- [x] go vet ./... clean
- [ ] rebase onto main once parent PR lands